### PR TITLE
feat: decision extraction + review council remediation (007/008)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -19,5 +19,8 @@ GCAL_FILENAME_KEYWORDS=Notes,Meeting
 # Default matches "Meeting Name - YYYY-MM-DD" format
 GCAL_FILENAME_PATTERN=(.+)\s*-\s*(\d{4}-\d{2}-\d{2})
 
-# Optional: Gemini model to use (default: gemini-1.5-flash)
-GEMINI_MODEL=gemini-1.5-flash
+# Optional: Gemini model to use (default: gemini-2.0-flash)
+GEMINI_MODEL=gemini-2.0-flash
+
+# Optional: Disable OS credential store; use file-based storage (default: false)
+# GCAL_NO_KEYRING=false

--- a/.opencode/agents/reviewer-architect.md
+++ b/.opencode/agents/reviewer-architect.md
@@ -38,7 +38,6 @@ Evaluate all recent changes (staged, unstaged, and untracked files). Use `git di
   - `internal/drive/` for Google Drive operations
   - `internal/calendar/` for Calendar operations
   - `internal/docs/` for Google Docs parsing
-  - `internal/tasks/` for Google Tasks operations
   - `internal/gemini/` for Gemini AI client
   - `internal/organizer/` for main orchestration logic
   - `internal/retry/` for retry with exponential backoff

--- a/.specify/memory/constitution.md
+++ b/.specify/memory/constitution.md
@@ -55,7 +55,7 @@ Error messages guide users to self-service tools.
 ### API Limitations
 - GCP Gemini API key (project: gcp-jflowers-pro-gemini)
 - Use `google.golang.org/genai` SDK
-- Model: gemini-1.5-flash (or configurable)
+- Model: gemini-2.0-flash (or configurable)
 - Handle rate limiting and quotas gracefully
 
 ### Google Workspace Integration

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -26,13 +26,13 @@ gcal-organizer/
 │   ├── auth/                    # OAuth2 and API key handling
 │   ├── config/                  # Configuration management
 │   ├── drive/                   # Google Drive operations
-│   ├── docs/                    # Google Docs parsing
+│   ├── docs/                    # Google Docs parsing + Decisions tab creation
 │   ├── calendar/                # Calendar operations
 │   ├── gemini/                  # Gemini AI client
 │   ├── secrets/                 # Credential storage abstraction (keychain/file)
 │   └── organizer/               # Main orchestration
 ├── pkg/models/                  # Shared data models
-├── scripts/                     # Browser automation (TypeScript)
+├── browser/                     # Browser automation (TypeScript)
 ├── .specify/                    # Spec-driven development artifacts
 └── .opencode/                   # OpenCode agent commands
 ```

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -7,6 +7,8 @@ Auto-generated from all feature plans. Last updated: 2026-02-17
 - N/A (no new data persistence; flag stored in config file via existing viper mechanism) (006-owned-only-flag)
 - Go 1.24+ (module `github.com/jflowers/gcal-organizer`) + `github.com/zalando/go-keyring` v0.2.6 (macOS Keychain via `/usr/bin/security`, Linux Secret Service via D-Bus — no CGo), `github.com/spf13/cobra` (CLI), `github.com/spf13/viper` (config), `golang.org/x/oauth2` (token handling), `github.com/charmbracelet/huh` (interactive prompts), `github.com/mattn/go-isatty` (terminal detection — already indirect dep) (007-secure-credential-storage)
 - OS credential store (primary), filesystem `~/.gcal-organizer/` (fallback). No database. (007-secure-credential-storage)
+- Go 1.24+ (module `github.com/jflowers/gcal-organizer`) + `google.golang.org/api/docs/v1` (Docs API — tab creation, content insertion, heading links), `google.golang.org/genai` (Gemini SDK — transcript analysis), `github.com/spf13/cobra` (CLI), `github.com/spf13/viper` (config) (008-decision-extraction)
+- N/A (no new data persistence; decisions written directly to Google Docs) (008-decision-extraction)
 
 - **Language**: Go 1.21+
 - **CLI Framework**: github.com/spf13/cobra
@@ -69,6 +71,7 @@ make install-hooks
 - New features require documentation before completion
 
 ## Recent Changes
+- 008-decision-extraction: Added Go 1.24+ (module `github.com/jflowers/gcal-organizer`) + `google.golang.org/api/docs/v1` (Docs API — tab creation, content insertion, heading links), `google.golang.org/genai` (Gemini SDK — transcript analysis), `github.com/spf13/cobra` (CLI), `github.com/spf13/viper` (config)
 - 007-secure-credential-storage: Added Go 1.24+ (module `github.com/jflowers/gcal-organizer`) + `github.com/zalando/go-keyring` v0.2.6 (macOS Keychain via `/usr/bin/security`, Linux Secret Service via D-Bus — no CGo), `github.com/spf13/cobra` (CLI), `github.com/spf13/viper` (config), `golang.org/x/oauth2` (token handling), `github.com/charmbracelet/huh` (interactive prompts), `github.com/mattn/go-isatty` (terminal detection — already indirect dep)
 - 006-owned-only-flag: Added Go 1.21+ + github.com/spf13/cobra (CLI), github.com/spf13/viper (config), Google Drive API v3
 

--- a/README.md
+++ b/README.md
@@ -5,19 +5,20 @@
 [![GitHub release](https://img.shields.io/github/v/release/jflowers/gcal-organizer)](https://github.com/jflowers/gcal-organizer/releases/latest)
 [![License](https://img.shields.io/github/license/jflowers/gcal-organizer)](LICENSE)
 
-A Go CLI tool that automates meeting note organization, calendar attachment syncing, and AI-powered task assignment using Google Workspace APIs and Gemini AI.
+A Go CLI tool that automates meeting note organization, calendar attachment syncing, AI-powered task assignment, and decision extraction using Google Workspace APIs and Gemini AI.
 
 ## ✨ What It Does
 
-GCal Organizer runs a 3-step workflow that keeps your Google Drive and Calendar in sync:
+GCal Organizer runs a 4-step workflow that keeps your Google Drive and Calendar in sync:
 
 | Step | Command | Description |
 |------|---------|-------------|
 | 1 | `organize` | Finds meeting docs in Drive and organizes them into topic-based folders |
 | 2 | `sync-calendar` | Links calendar attachments to meeting folders, shares with attendees |
 | 3 | `assign-tasks` | Locates checkbox action items in Google Docs `Notes by Gemini` and assigns them if Gemini can determine the assignee  |
+| 4 | *(automatic)* | Extracts decisions from meeting transcripts and creates a "Decisions" tab with categorized sections |
 
-Run all three with `gcal-organizer run`, or each step individually.
+Run all four with `gcal-organizer run`, or steps 1-3 individually.
 
 ### How the Folder Routing Works
 
@@ -134,7 +135,7 @@ man gcal-organizer
 
 | Command | Description |
 |---------|-------------|
-| `gcal-organizer run` | Run the full 3-step workflow |
+| `gcal-organizer run` | Run the full 4-step workflow |
 | `gcal-organizer organize` | Step 1 only: organize documents into folders |
 | `gcal-organizer sync-calendar` | Step 2 only: sync calendar attachments |
 | `gcal-organizer assign-tasks --doc <ID>` | Step 3 only: assign tasks from a specific doc |
@@ -188,14 +189,32 @@ GCAL_DAYS_TO_LOOK_BACK=1                  # Default: 1
 GCAL_OWNED_ONLY=true                      # Default: false (only mutate owned files)
 GCAL_FILENAME_KEYWORDS="Notes,Meeting"    # Comma-separated
 GCAL_FILENAME_PATTERN="(.+)\s*-\s*(\d{4}-\d{2}-\d{2})"
-GEMINI_MODEL="gemini-1.5-flash"           # Default: gemini-1.5-flash
+GEMINI_MODEL="gemini-2.0-flash"           # Default: gemini-2.0-flash
 ```
 
 ## 🔒 Data Privacy
 
-**What goes to Gemini AI**: Only the text of individual checkbox items (e.g., `"@jordan review the API spec by Friday"`). The tool does *not* upload full document contents — it extracts checkbox text via the Google Docs API and sends only that single line to Gemini for assignee extraction.
+**What goes to Gemini AI**: Individual checkbox items for task assignment (e.g., `"@jordan review the API spec by Friday"`) and full transcript text for decision extraction. The tool does *not* upload entire documents for task assignment — it extracts checkbox text via the Google Docs API. For decision extraction (Step 4), the full transcript tab content is sent to Gemini for analysis.
 
-**What stays local**: OAuth tokens, credentials, and configuration are stored at `~/.gcal-organizer/` and never transmitted.
+**What stays local**: OAuth tokens, credentials, and configuration are stored securely and never transmitted.
+
+### Secure Credential Storage
+
+By default, OAuth tokens, the Gemini API key, and client credentials are stored in your OS credential store (macOS Keychain or Linux Secret Service). This prevents sensitive data from being stored as plaintext files on disk.
+
+| Data | Default Storage | Fallback |
+|------|----------------|----------|
+| OAuth token | OS keychain | `~/.gcal-organizer/token.json` |
+| Gemini API key | OS keychain | `~/.gcal-organizer/.env` |
+| Client credentials | OS keychain | `~/.gcal-organizer/credentials.json` |
+
+To disable keychain storage (e.g., on headless servers without a credential store):
+
+```bash
+gcal-organizer run --no-keyring
+# or
+export GCAL_NO_KEYRING=true
+```
 
 ## 🤖 Why Browser Automation for Task Assignment?
 
@@ -208,6 +227,22 @@ The Google Docs API provides read access to document content (including checkbox
 
 This requires Chrome with your Google profile for authentication. See [Browser Automation Setup](docs/SETUP.md#browser-automation-setup) for details.
 
+## 📋 Step 4: Decision Extraction
+
+Step 4 automatically processes meeting transcript documents to extract and categorize decisions:
+
+1. During calendar sync (Step 2), the tool identifies documents titled "Notes by Gemini" (exact match) or ending with "- Transcript" (suffix match)
+2. For each eligible document, it reads the transcript content and sends it to Gemini AI
+3. Gemini extracts decisions into three categories:
+   - **Decisions Made** -- commitments the team agreed on
+   - **Decisions Deferred** -- items explicitly tabled for later
+   - **Open Items** -- unresolved topics needing further discussion
+4. A new "Decisions" tab is created in the document with clickable timestamp links back to the transcript
+
+**Idempotent**: Documents with an existing "Decisions" tab are automatically skipped. Safe to run repeatedly.
+
+**Error handling**: If Gemini fails on a document, it's skipped with a warning. The next run will retry since no tab was created.
+
 ## 📁 Project Structure
 
 ```
@@ -217,11 +252,10 @@ gcal-organizer/
 │   ├── auth/                  # OAuth2 + Gemini API auth
 │   ├── calendar/              # Calendar event operations
 │   ├── config/                # Configuration management
-│   ├── docs/                  # Docs checkbox extraction
+│   ├── docs/                  # Docs checkbox extraction + decision tab creation
 │   ├── drive/                 # Drive folder/file operations
-│   ├── gemini/                # Gemini AI assignee extraction
-│   ├── organizer/             # Workflow orchestration
-│   └── tasks/                 # Google Tasks creation
+│   ├── gemini/                # Gemini AI assignee + decision extraction
+│   └── organizer/             # Workflow orchestration
 ├── browser/                   # Playwright task assignment script (TypeScript)
 ├── deploy/                    # Service files (launchd, systemd)
 ├── .specify/                  # Spec-kit artifacts

--- a/cmd/gcal-organizer/assign_tasks.go
+++ b/cmd/gcal-organizer/assign_tasks.go
@@ -17,6 +17,7 @@ import (
 	"github.com/jflowers/gcal-organizer/internal/docs"
 	"github.com/jflowers/gcal-organizer/internal/drive"
 	"github.com/jflowers/gcal-organizer/internal/gemini"
+	"github.com/jflowers/gcal-organizer/internal/secrets"
 	"github.com/jflowers/gcal-organizer/internal/ux"
 	"github.com/spf13/cobra"
 )
@@ -35,14 +36,15 @@ This command:
 
 Requires: Node.js and the browser/ directory to be set up.`,
 	RunE: func(cmd *cobra.Command, args []string) error {
-		ctx := context.Background()
+		ctx, stop := signal.NotifyContext(context.Background(), syscall.SIGINT, syscall.SIGTERM)
+		defer stop()
 
 		docID, _ := cmd.Flags().GetString("doc")
 		if docID == "" {
 			return fmt.Errorf("--doc flag is required")
 		}
 
-		cfg, err := config.Load()
+		cfg, store, _, err := loadConfigAndStore()
 		if err != nil {
 			return fmt.Errorf("failed to load config: %w", err)
 		}
@@ -52,7 +54,7 @@ Requires: Node.js and the browser/ directory to be set up.`,
 
 		// When --owned-only is active, verify ownership before processing
 		if ownedOnly {
-			owned, checkErr := checkDocOwnership(ctx, cfg, docID)
+			owned, checkErr := checkDocOwnership(ctx, cfg, store, docID)
 			if checkErr != nil {
 				return fmt.Errorf("cannot verify ownership of document %s: %w\n\nRun 'gcal-organizer doctor' for diagnostics", docID, checkErr)
 			}
@@ -70,17 +72,17 @@ Requires: Node.js and the browser/ directory to be set up.`,
 		fmt.Printf("📄 Processing document: %s\n\n", docID)
 
 		if dryRun {
-			return runAssignTasksDryRun(ctx, cfg, docID)
+			return runAssignTasksDryRun(ctx, cfg, store, docID)
 		}
-		return runAssignTasksBrowser(ctx, cfg, docID)
+		return runAssignTasksBrowser(ctx, cfg, store, docID)
 	},
 }
 
 // checkDocOwnership initialises a Drive service and checks whether the
 // authenticated user owns the given document. Used by the assign-tasks
 // command to enforce --owned-only before any processing begins.
-func checkDocOwnership(ctx context.Context, cfg *config.Config, docID string) (bool, error) {
-	oauthClient, err := auth.NewOAuthClient(cfg.CredentialsFile, cfg.TokenFile)
+func checkDocOwnership(ctx context.Context, cfg *config.Config, store secrets.SecretStore, docID string) (bool, error) {
+	oauthClient, err := auth.NewOAuthClient(store, cfg.CredentialsFile)
 	if err != nil {
 		return false, fmt.Errorf("OAuth setup failed: %w", err)
 	}
@@ -97,8 +99,8 @@ func checkDocOwnership(ctx context.Context, cfg *config.Config, docID string) (b
 
 // initDocsAndGemini is a shared helper that initialises the Docs service and
 // Gemini client, both of which are required by every assign-tasks flow.
-func initDocsAndGemini(ctx context.Context, cfg *config.Config) (*docs.Service, *gemini.Client, error) {
-	oauthClient, err := auth.NewOAuthClient(cfg.CredentialsFile, cfg.TokenFile)
+func initDocsAndGemini(ctx context.Context, cfg *config.Config, store secrets.SecretStore) (*docs.Service, *gemini.Client, error) {
+	oauthClient, err := auth.NewOAuthClient(store, cfg.CredentialsFile)
 	if err != nil {
 		return nil, nil, ux.OAuthSetupFailed(cfg.CredentialsFile)
 	}
@@ -131,8 +133,8 @@ func extractUnassignedItems(checkboxes []*docs.CheckboxItem) []gemini.CheckboxIt
 }
 
 // runAssignTasksDryRun analyses a document and prints what would be assigned.
-func runAssignTasksDryRun(ctx context.Context, cfg *config.Config, docID string) error {
-	docsSvc, geminiClient, err := initDocsAndGemini(ctx, cfg)
+func runAssignTasksDryRun(ctx context.Context, cfg *config.Config, store secrets.SecretStore, docID string) error {
+	docsSvc, geminiClient, err := initDocsAndGemini(ctx, cfg, store)
 	if err != nil {
 		return err
 	}
@@ -193,8 +195,8 @@ type scriptOutput struct {
 }
 
 // runAssignTasksBrowser extracts assignees then invokes the Playwright script.
-func runAssignTasksBrowser(ctx context.Context, cfg *config.Config, docID string) error {
-	docsSvc, geminiClient, err := initDocsAndGemini(ctx, cfg)
+func runAssignTasksBrowser(ctx context.Context, cfg *config.Config, store secrets.SecretStore, docID string) error {
+	docsSvc, geminiClient, err := initDocsAndGemini(ctx, cfg, store)
 	if err != nil {
 		return err
 	}
@@ -362,8 +364,8 @@ func findBrowserDir() (string, error) {
 
 // runAssignTasksForDoc scans a document for unassigned checkboxes and runs
 // browser automation to assign them. Returns (assigned, failed, error).
-func runAssignTasksForDoc(ctx context.Context, cfg *config.Config, docID string) (int, int, error) {
-	docsSvc, geminiClient, err := initDocsAndGemini(ctx, cfg)
+func runAssignTasksForDoc(ctx context.Context, cfg *config.Config, store secrets.SecretStore, docID string) (int, int, error) {
+	docsSvc, geminiClient, err := initDocsAndGemini(ctx, cfg, store)
 	if err != nil {
 		return 0, 0, err
 	}

--- a/cmd/gcal-organizer/auth_config.go
+++ b/cmd/gcal-organizer/auth_config.go
@@ -4,9 +4,11 @@ import (
 	"context"
 	"fmt"
 	"os"
+	"os/signal"
+	"syscall"
 
 	"github.com/jflowers/gcal-organizer/internal/auth"
-	"github.com/jflowers/gcal-organizer/internal/config"
+	"github.com/jflowers/gcal-organizer/internal/secrets"
 	"github.com/spf13/cobra"
 )
 
@@ -25,7 +27,7 @@ var configShowCmd = &cobra.Command{
 	Short: "Show current configuration",
 	Long:  `Display the merged configuration from environment variables and config file.`,
 	RunE: func(cmd *cobra.Command, args []string) error {
-		cfg, err := config.Load()
+		cfg, store, backend, err := loadConfigAndStore()
 		if err != nil {
 			return fmt.Errorf("failed to load config: %w", err)
 		}
@@ -38,17 +40,23 @@ var configShowCmd = &cobra.Command{
 		fmt.Printf("   Gemini Model:      %s\n", cfg.GeminiModel)
 		fmt.Printf("   Gemini API Key:    %s\n", maskSecret(cfg.GeminiAPIKey))
 		fmt.Printf("   Credentials File:  %s\n", cfg.CredentialsFile)
-		fmt.Printf("   Token File:        %s\n", cfg.TokenFile)
+		fmt.Printf("   Secret storage:    %s\n", backend)
 		fmt.Println("───────────────────────────────────────────────────────────")
 
-		if _, err := os.Stat(cfg.CredentialsFile); os.IsNotExist(err) {
+		// Check credentials in store first, then file
+		if _, credErr := store.Get(secrets.KeyClientCredentials); credErr == nil {
+			fmt.Println("✅ OAuth credentials found (in secret store)")
+		} else if _, err := os.Stat(cfg.CredentialsFile); os.IsNotExist(err) {
 			fmt.Println("⚠️  OAuth credentials not found!")
 			fmt.Printf("   Download from Google Cloud Console and save to:\n   %s\n", cfg.CredentialsFile)
 		} else {
 			fmt.Println("✅ OAuth credentials file found")
 		}
 
-		if _, err := os.Stat(cfg.TokenFile); os.IsNotExist(err) {
+		// Check token in store first, then file
+		if _, tokErr := store.Get(secrets.KeyOAuthToken); tokErr == nil {
+			fmt.Println("✅ OAuth token found (authenticated)")
+		} else if _, err := os.Stat(cfg.TokenFile); os.IsNotExist(err) {
 			fmt.Println("⚠️  Not authenticated - run 'gcal-organizer auth login'")
 		} else {
 			fmt.Println("✅ OAuth token found (authenticated)")
@@ -73,9 +81,10 @@ var authLoginCmd = &cobra.Command{
 	Short: "Login to Google Workspace",
 	Long:  `Start the OAuth2 flow to authenticate with Google Workspace APIs.`,
 	RunE: func(cmd *cobra.Command, args []string) error {
-		ctx := context.Background()
+		ctx, stop := signal.NotifyContext(context.Background(), syscall.SIGINT, syscall.SIGTERM)
+		defer stop()
 
-		cfg, err := config.Load()
+		cfg, store, _, err := loadConfigAndStore()
 		if err != nil {
 			return fmt.Errorf("failed to load config: %w", err)
 		}
@@ -83,9 +92,14 @@ var authLoginCmd = &cobra.Command{
 		fmt.Println("🔐 Starting OAuth2 login flow...")
 		fmt.Println("")
 
-		oauthClient, err := auth.NewOAuthClient(cfg.CredentialsFile, cfg.TokenFile)
+		oauthClient, err := auth.NewOAuthClient(store, cfg.CredentialsFile)
 		if err != nil {
 			return fmt.Errorf("failed to create OAuth client: %w\n\nTo set up OAuth:\n1. Go to https://console.cloud.google.com\n2. Create OAuth 2.0 credentials (Desktop app)\n3. Download and save to: %s\n\nRun 'gcal-organizer doctor' for full diagnostics", err, cfg.CredentialsFile)
+		}
+
+		// After successful credential loading, persist to store for future use
+		if credsData, readErr := os.ReadFile(cfg.CredentialsFile); readErr == nil {
+			_ = store.Set(secrets.KeyClientCredentials, string(credsData))
 		}
 
 		_, err = oauthClient.GetClient(ctx)
@@ -95,7 +109,7 @@ var authLoginCmd = &cobra.Command{
 
 		fmt.Println("")
 		fmt.Println("✅ Authentication successful!")
-		fmt.Printf("   Token saved to: %s\n", cfg.TokenFile)
+		fmt.Println("   Token saved to secret store")
 		fmt.Println("")
 		fmt.Println("You can now run: gcal-organizer run --dry-run")
 		return nil
@@ -107,31 +121,29 @@ var authStatusCmd = &cobra.Command{
 	Short: "Check authentication status",
 	Long:  `Check if OAuth authentication is configured and valid.`,
 	RunE: func(cmd *cobra.Command, args []string) error {
-		cfg, err := config.Load()
+		cfg, store, backend, err := loadConfigAndStore()
 		if err != nil {
 			return fmt.Errorf("failed to load config: %w", err)
 		}
 
 		fmt.Println("🔐 Authentication Status:")
 		fmt.Println("───────────────────────────────────────────────────────────")
+		fmt.Printf("   Secret storage: %s\n", backend)
 
-		if _, err := os.Stat(cfg.CredentialsFile); os.IsNotExist(err) {
-			fmt.Println("❌ OAuth credentials file NOT found")
+		// Check credentials in store first, then file
+		if _, credErr := store.Get(secrets.KeyClientCredentials); credErr == nil {
+			fmt.Println("✅ OAuth credentials found (in secret store)")
+		} else if _, err := os.Stat(cfg.CredentialsFile); os.IsNotExist(err) {
+			fmt.Println("❌ OAuth credentials NOT found")
 			fmt.Printf("   Expected: %s\n", cfg.CredentialsFile)
 			fmt.Println("")
 			fmt.Println("To fix: Download OAuth credentials from Google Cloud Console")
 			return nil
-		}
-		fmt.Println("✅ OAuth credentials file found")
-
-		if _, err := os.Stat(cfg.TokenFile); os.IsNotExist(err) {
-			fmt.Println("❌ Not authenticated")
-			fmt.Println("")
-			fmt.Println("Run: gcal-organizer auth login")
-			return nil
+		} else {
+			fmt.Println("✅ OAuth credentials file found")
 		}
 
-		oauthClient, err := auth.NewOAuthClient(cfg.CredentialsFile, cfg.TokenFile)
+		oauthClient, err := auth.NewOAuthClient(store, cfg.CredentialsFile)
 		if err != nil {
 			fmt.Printf("❌ Error loading credentials: %v\n", err)
 			return nil

--- a/cmd/gcal-organizer/main.go
+++ b/cmd/gcal-organizer/main.go
@@ -13,8 +13,11 @@ import (
 	"context"
 	"fmt"
 	"os"
+	"os/signal"
 	"path/filepath"
+	"regexp"
 	"strings"
+	"syscall"
 
 	"github.com/jflowers/gcal-organizer/internal/auth"
 	"github.com/jflowers/gcal-organizer/internal/calendar"
@@ -22,8 +25,10 @@ import (
 	"github.com/jflowers/gcal-organizer/internal/drive"
 	"github.com/jflowers/gcal-organizer/internal/logging"
 	"github.com/jflowers/gcal-organizer/internal/organizer"
+	"github.com/jflowers/gcal-organizer/internal/secrets"
 	"github.com/jflowers/gcal-organizer/internal/ux"
 	"github.com/spf13/cobra"
+	"github.com/spf13/pflag"
 	"github.com/spf13/viper"
 )
 
@@ -37,6 +42,14 @@ var (
 	dryRun    bool
 	ownedOnly bool
 )
+
+// mustBindPFlag wraps viper.BindPFlag and panics on error. Errors here indicate
+// a programming mistake (typo in flag name) and should surface at startup.
+func mustBindPFlag(key string, flag *pflag.Flag) {
+	if err := viper.BindPFlag(key, flag); err != nil {
+		panic(fmt.Sprintf("viper.BindPFlag(%q) failed: %v", key, err))
+	}
+}
 
 // rootCmd represents the base command when called without any subcommands
 var rootCmd = &cobra.Command{
@@ -53,9 +66,22 @@ Use the subcommands to run specific operations or 'run' for the full workflow.`,
 	Version: Version,
 }
 
+// loadConfigAndStore loads configuration and creates a SecretStore.
+// This is the standard startup sequence for all commands that need secrets.
+// Returns the backend so callers can display it without re-probing the keychain.
+func loadConfigAndStore() (*config.Config, secrets.SecretStore, secrets.Backend, error) {
+	cfg, err := config.Load()
+	if err != nil {
+		return nil, nil, 0, err
+	}
+	store, backend := secrets.NewStore(cfg.NoKeyring)
+	cfg.LoadSecrets(store)
+	return cfg, store, backend, nil
+}
+
 // initServices initializes all Google API services and returns an Organizer.
-func initServices(ctx context.Context, cfg *config.Config) (*organizer.Organizer, error) {
-	oauthClient, err := auth.NewOAuthClient(cfg.CredentialsFile, cfg.TokenFile)
+func initServices(ctx context.Context, cfg *config.Config, store secrets.SecretStore) (*organizer.Organizer, error) {
+	oauthClient, err := auth.NewOAuthClient(store, cfg.CredentialsFile)
 	if err != nil {
 		return nil, ux.OAuthSetupFailed(cfg.CredentialsFile)
 	}
@@ -84,9 +110,10 @@ var runCmd = &cobra.Command{
 	Short: "Run the complete workflow",
 	Long:  `Execute all operations: organize documents, sync calendar attachments, and assign tasks.`,
 	RunE: func(cmd *cobra.Command, args []string) error {
-		ctx := context.Background()
+		ctx, stop := signal.NotifyContext(context.Background(), syscall.SIGINT, syscall.SIGTERM)
+		defer stop()
 
-		cfg, err := config.Load()
+		cfg, store, _, err := loadConfigAndStore()
 		if err != nil {
 			return fmt.Errorf("failed to load config: %w\n\nRun 'gcal-organizer doctor' for diagnostics", err)
 		}
@@ -102,7 +129,7 @@ var runCmd = &cobra.Command{
 			cfg.DaysToLookBack = days
 		}
 
-		org, err := initServices(ctx, cfg)
+		org, err := initServices(ctx, cfg, store)
 		if err != nil {
 			return err
 		}
@@ -126,7 +153,7 @@ var runCmd = &cobra.Command{
 			totalFailed := 0
 
 			for _, docID := range docIDs {
-				assigned, failed, err := runAssignTasksForDoc(ctx, cfg, docID)
+				assigned, failed, err := runAssignTasksForDoc(ctx, cfg, store, docID)
 				if err != nil {
 					fmt.Printf("   ⚠️  Error processing doc %s: %v\n", docID[:min(8, len(docID))], err)
 					continue
@@ -139,6 +166,45 @@ var runCmd = &cobra.Command{
 			fmt.Println()
 		} else if len(docIDs) > 0 && dryRun {
 			fmt.Printf("📝 STEP 3: Would scan %d Notes documents for task assignments\n", len(docIDs))
+			fmt.Println()
+		}
+
+		// Step 4: Extract Decisions from transcript documents
+		decisionDocIDs := org.GetDecisionDocIDs()
+		if ownedOnly && len(decisionDocIDs) == 0 {
+			fmt.Println("📋 STEP 4: No owned transcript documents found for decision extraction")
+		}
+		if len(decisionDocIDs) > 0 {
+			if dryRun {
+				fmt.Printf("📋 STEP 4: Would extract decisions from %d transcript documents\n", len(decisionDocIDs))
+			} else {
+				fmt.Println("📋 STEP 4: Extracting Decisions")
+				fmt.Println("───────────────────────────────────────────────────────────")
+				fmt.Printf("   Found %d transcript documents to process\n", len(decisionDocIDs))
+			}
+
+			// Initialize services once for all documents
+			docsSvc, geminiClient, initErr := initDocsAndGemini(ctx, cfg, store)
+			if initErr != nil {
+				fmt.Printf("   ⚠️  Error initializing services for Step 4: %v\n", initErr)
+			} else {
+				totalFailed := 0
+
+				for docID, source := range decisionDocIDs {
+					if !dryRun {
+						fmt.Printf("   📄 Processing doc %s (source: %s)\n", docID[:min(8, len(docID))], source)
+					}
+					err := org.ExtractDecisionsForDoc(ctx, docID, docsSvc, geminiClient, dryRun)
+					if err != nil {
+						fmt.Printf("   ⚠️  Error processing doc %s: %v\n", docID[:min(8, len(docID))], err)
+						totalFailed++
+					}
+				}
+
+				// Only add externally-tracked failures; processed/skipped counts are
+				// managed internally by ExtractDecisionsForDoc via organizer stats.
+				org.AddDecisionStats(0, 0, totalFailed)
+			}
 			fmt.Println()
 		}
 
@@ -155,9 +221,10 @@ var organizeCmd = &cobra.Command{
 	Short: "Organize meeting documents into folders",
 	Long:  `Scan Google Drive for meeting notes and organize them into topic-based subfolders.`,
 	RunE: func(cmd *cobra.Command, args []string) error {
-		ctx := context.Background()
+		ctx, stop := signal.NotifyContext(context.Background(), syscall.SIGINT, syscall.SIGTERM)
+		defer stop()
 
-		cfg, err := config.Load()
+		cfg, store, _, err := loadConfigAndStore()
 		if err != nil {
 			return fmt.Errorf("failed to load config: %w", err)
 		}
@@ -165,7 +232,7 @@ var organizeCmd = &cobra.Command{
 		cfg.Verbose = verbose
 		cfg.OwnedOnly = ownedOnly
 
-		org, err := initServices(ctx, cfg)
+		org, err := initServices(ctx, cfg, store)
 		if err != nil {
 			return err
 		}
@@ -186,9 +253,10 @@ var syncCalendarCmd = &cobra.Command{
 	Short: "Sync calendar attachments to meeting folders",
 	Long:  `Scan recent calendar events and sync any attached documents to corresponding meeting folders.`,
 	RunE: func(cmd *cobra.Command, args []string) error {
-		ctx := context.Background()
+		ctx, stop := signal.NotifyContext(context.Background(), syscall.SIGINT, syscall.SIGTERM)
+		defer stop()
 
-		cfg, err := config.Load()
+		cfg, store, _, err := loadConfigAndStore()
 		if err != nil {
 			return fmt.Errorf("failed to load config: %w", err)
 		}
@@ -204,7 +272,7 @@ var syncCalendarCmd = &cobra.Command{
 		cfg.Verbose = verbose
 		cfg.OwnedOnly = ownedOnly
 
-		org, err := initServices(ctx, cfg)
+		org, err := initServices(ctx, cfg, store)
 		if err != nil {
 			return err
 		}
@@ -248,11 +316,14 @@ func init() {
 	rootCmd.PersistentFlags().BoolVarP(&verbose, "verbose", "v", false, "verbose output")
 	rootCmd.PersistentFlags().BoolVar(&dryRun, "dry-run", false, "show what would be done without making changes")
 	rootCmd.PersistentFlags().BoolVar(&ownedOnly, "owned-only", false, "only mutate files you own; skip non-owned files")
+	rootCmd.PersistentFlags().Bool("no-keyring", false, "disable OS credential store; use file-based storage")
 
-	// Bind flags to viper
-	viper.BindPFlag("verbose", rootCmd.PersistentFlags().Lookup("verbose"))
-	viper.BindPFlag("dry-run", rootCmd.PersistentFlags().Lookup("dry-run"))
-	viper.BindPFlag("owned-only", rootCmd.PersistentFlags().Lookup("owned-only"))
+	// Bind flags to viper. Errors here indicate a programming mistake (typo in
+	// flag name) and should surface immediately at startup.
+	mustBindPFlag("verbose", rootCmd.PersistentFlags().Lookup("verbose"))
+	mustBindPFlag("dry-run", rootCmd.PersistentFlags().Lookup("dry-run"))
+	mustBindPFlag("owned-only", rootCmd.PersistentFlags().Lookup("owned-only"))
+	mustBindPFlag("no-keyring", rootCmd.PersistentFlags().Lookup("no-keyring"))
 
 	// Add flags to specific commands
 	syncCalendarCmd.Flags().Int("days", 8, "number of days to look back for calendar events")
@@ -302,6 +373,9 @@ func initConfig() {
 	logging.SetVerbose(verbose)
 }
 
+// validEnvKey matches a valid POSIX environment variable name.
+var validEnvKey = regexp.MustCompile(`^[A-Za-z_][A-Za-z0-9_]*$`)
+
 // loadDotEnv reads a .env file and sets any KEY=VALUE pairs as environment
 // variables, but only if they are not already set (env vars take precedence).
 // Tilde (~) in values is expanded to the user's home directory.
@@ -323,7 +397,7 @@ func loadDotEnv(path, home string) {
 			continue
 		}
 		key := strings.TrimSpace(parts[0])
-		if key == "" || strings.ContainsAny(key, "=\x00") {
+		if !validEnvKey.MatchString(key) {
 			continue
 		}
 		val := strings.TrimSpace(parts[1])

--- a/cmd/gcal-organizer/selfservice.go
+++ b/cmd/gcal-organizer/selfservice.go
@@ -14,6 +14,7 @@ import (
 
 	"github.com/charmbracelet/huh"
 	"github.com/charmbracelet/lipgloss"
+	"github.com/jflowers/gcal-organizer/internal/secrets"
 	"github.com/spf13/cobra"
 	"golang.org/x/oauth2"
 )
@@ -113,33 +114,57 @@ var doctorCmd = &cobra.Command{
 			failed++
 		}
 
-		// 4. token.json (OAuth token)
+		// 4. OAuth token (check store first, then file fallback)
 		tokenFile := filepath.Join(configDir, "token.json")
-		if _, err := os.Stat(tokenFile); err == nil {
-			// Check if token is valid
-			f, err := os.Open(tokenFile)
-			if err == nil {
-				defer f.Close()
-				var tok oauth2.Token
-				if err := json.NewDecoder(f).Decode(&tok); err == nil {
-					if tok.Expiry.After(time.Now()) || tok.RefreshToken != "" {
-						fmt.Println(styledPass("OAuth token found (authenticated)"))
-						if verbose {
-							fmt.Println(subtleStyle.Render("          " + tokenFile))
-						}
-						passed++
-					} else {
-						fmt.Println(styledWarn("OAuth token exists but may be expired"))
-						fmt.Println(styledFix("Run 'gcal-organizer auth login' to re-authenticate"))
-						warned++
-					}
+		tokenFound := false
+		// Try the secret store first (keychain or file-based)
+		store, backend := secrets.NewStore(false)
+		if tokData, tokErr := store.Get(secrets.KeyOAuthToken); tokErr == nil && tokData != "" {
+			var tok oauth2.Token
+			if err := json.Unmarshal([]byte(tokData), &tok); err == nil {
+				if tok.Expiry.After(time.Now()) || tok.RefreshToken != "" {
+					fmt.Println(styledPass(fmt.Sprintf("OAuth token found (%s)", backend)))
+					passed++
+					tokenFound = true
 				} else {
-					fmt.Println(styledWarn("OAuth token file is corrupted"))
+					fmt.Println(styledWarn("OAuth token exists but may be expired"))
 					fmt.Println(styledFix("Run 'gcal-organizer auth login' to re-authenticate"))
 					warned++
+					tokenFound = true
 				}
 			}
-		} else {
+		}
+		// Fallback: check token.json on disk
+		if !tokenFound {
+			if _, err := os.Stat(tokenFile); err == nil {
+				f, err := os.Open(tokenFile)
+				if err == nil {
+					defer f.Close()
+					var tok oauth2.Token
+					if err := json.NewDecoder(f).Decode(&tok); err == nil {
+						if tok.Expiry.After(time.Now()) || tok.RefreshToken != "" {
+							fmt.Println(styledPass("OAuth token found (file)"))
+							if verbose {
+								fmt.Println(subtleStyle.Render("          " + tokenFile))
+							}
+							passed++
+							tokenFound = true
+						} else {
+							fmt.Println(styledWarn("OAuth token exists but may be expired"))
+							fmt.Println(styledFix("Run 'gcal-organizer auth login' to re-authenticate"))
+							warned++
+							tokenFound = true
+						}
+					} else {
+						fmt.Println(styledWarn("OAuth token file is corrupted"))
+						fmt.Println(styledFix("Run 'gcal-organizer auth login' to re-authenticate"))
+						warned++
+						tokenFound = true
+					}
+				}
+			}
+		}
+		if !tokenFound {
 			fmt.Println(styledFail("Not authenticated — no OAuth token found"))
 			fmt.Println(styledFix("Run 'gcal-organizer auth login'"))
 			failed++
@@ -905,7 +930,10 @@ This command:
 		fmt.Println()
 
 		reader := bufio.NewReader(os.Stdin)
-		reader.ReadString('\n')
+		if _, err := reader.ReadString('\n'); err != nil {
+			// Non-interactive (stdin closed) — continue without waiting
+			fmt.Println(styledWarn("stdin not available — skipping interactive pause"))
+		}
 
 		// Verify CDP is accessible
 		if isPortOpen(9222) {

--- a/deploy/run-wrapper.sh
+++ b/deploy/run-wrapper.sh
@@ -12,9 +12,6 @@ if [ -f "$ENV_FILE" ]; then
     set +a
 fi
 
-# Override days to look back for service mode (1 day)
-export GCAL_DAYS_TO_LOOK_BACK=1
-
 # --- Log rotation (FR-016) ---
 # Rotate log when it exceeds 5 MB, keeping one backup (.1).
 # Max disk usage: ~10 MB (5 MB active + 5 MB rotated).
@@ -44,9 +41,8 @@ else
     fi
 fi
 
-# Change to project root so browser/ directory is found
-cd /Users/jflowers/Projects/github/jflowers/gcal-organizer
-
 echo "$(date '+%Y-%m-%d %H:%M:%S') — Starting gcal-organizer run"
-"$BINARY" run #--verbose
+echo "$BINARY run"
+"$BINARY" run
+echo "Exit code: $?"
 echo "$(date '+%Y-%m-%d %H:%M:%S') — Completed gcal-organizer run"

--- a/go.mod
+++ b/go.mod
@@ -9,6 +9,7 @@ require (
 	github.com/charmbracelet/lipgloss v1.1.0
 	github.com/charmbracelet/log v0.4.2
 	github.com/spf13/cobra v1.10.2
+	github.com/spf13/pflag v1.0.10
 	github.com/spf13/viper v1.21.0
 	github.com/zalando/go-keyring v0.2.6
 	golang.org/x/oauth2 v0.34.0
@@ -64,7 +65,6 @@ require (
 	github.com/sourcegraph/conc v0.3.1-0.20240121214520-5f936abd7ae8 // indirect
 	github.com/spf13/afero v1.15.0 // indirect
 	github.com/spf13/cast v1.10.0 // indirect
-	github.com/spf13/pflag v1.0.10 // indirect
 	github.com/subosito/gotenv v1.6.0 // indirect
 	github.com/xo/terminfo v0.0.0-20220910002029-abceb7e1c41e // indirect
 	go.opentelemetry.io/auto/sdk v1.2.1 // indirect

--- a/internal/auth/oauth.go
+++ b/internal/auth/oauth.go
@@ -9,8 +9,9 @@ import (
 	"fmt"
 	"net/http"
 	"os"
-	"path/filepath"
+	"sync"
 
+	"github.com/jflowers/gcal-organizer/internal/secrets"
 	"golang.org/x/oauth2"
 	"golang.org/x/oauth2/google"
 	"google.golang.org/api/calendar/v3"
@@ -27,16 +28,26 @@ var Scopes = []string{
 
 // OAuthClient handles OAuth2 authentication for Google Workspace APIs.
 type OAuthClient struct {
-	config     *oauth2.Config
-	tokenFile  string
-	httpClient *http.Client
+	config            *oauth2.Config
+	store             secrets.SecretStore
+	credsFallbackPath string
+	httpClient        *http.Client
 }
 
-// NewOAuthClient creates a new OAuth client from credentials file.
-func NewOAuthClient(credentialsFile, tokenFile string) (*OAuthClient, error) {
-	b, err := os.ReadFile(credentialsFile)
-	if err != nil {
-		return nil, fmt.Errorf("unable to read credentials file: %w", err)
+// NewOAuthClient creates a new OAuth client. It loads client credentials from
+// the SecretStore first, falling back to reading the file at credsFallbackPath.
+func NewOAuthClient(store secrets.SecretStore, credsFallbackPath string) (*OAuthClient, error) {
+	// Try loading credentials from the store first
+	var b []byte
+	credsJSON, err := store.Get(secrets.KeyClientCredentials)
+	if err == nil && credsJSON != "" {
+		b = []byte(credsJSON)
+	} else {
+		// Fall back to reading from the file
+		b, err = os.ReadFile(credsFallbackPath)
+		if err != nil {
+			return nil, fmt.Errorf("unable to read credentials: %w\n\nTo set up OAuth:\n1. Go to https://console.cloud.google.com\n2. Create OAuth 2.0 credentials (Desktop app)\n3. Download and save to: %s\n\nRun 'gcal-organizer doctor' for diagnostics", err, credsFallbackPath)
+		}
 	}
 
 	config, err := google.ConfigFromJSON(b, Scopes...)
@@ -45,13 +56,15 @@ func NewOAuthClient(credentialsFile, tokenFile string) (*OAuthClient, error) {
 	}
 
 	return &OAuthClient{
-		config:    config,
-		tokenFile: tokenFile,
+		config:            config,
+		store:             store,
+		credsFallbackPath: credsFallbackPath,
 	}, nil
 }
 
 // GetClient returns an authenticated HTTP client.
 // If no cached token exists, it will prompt for authorization.
+// Token refresh is automatically persisted via persistingTokenSource.
 func (o *OAuthClient) GetClient(ctx context.Context) (*http.Client, error) {
 	if o.httpClient != nil {
 		return o.httpClient, nil
@@ -69,38 +82,74 @@ func (o *OAuthClient) GetClient(ctx context.Context) (*http.Client, error) {
 		}
 	}
 
-	o.httpClient = o.config.Client(ctx, tok)
+	// Wrap the token source with persistingTokenSource so refreshed tokens
+	// are saved back to the store automatically.
+	baseTS := o.config.TokenSource(ctx, tok)
+	persistTS := &persistingTokenSource{
+		base:    baseTS,
+		store:   o.store,
+		current: tok,
+	}
+
+	o.httpClient = oauth2.NewClient(ctx, persistTS)
 	return o.httpClient, nil
 }
 
-// loadToken reads the cached OAuth token from file.
+// loadToken reads the cached OAuth token from the SecretStore.
 func (o *OAuthClient) loadToken() (*oauth2.Token, error) {
-	f, err := os.Open(o.tokenFile)
+	data, err := o.store.Get(secrets.KeyOAuthToken)
 	if err != nil {
 		return nil, err
 	}
-	defer f.Close()
 
 	tok := &oauth2.Token{}
-	err = json.NewDecoder(f).Decode(tok)
-	return tok, err
+	if err := json.Unmarshal([]byte(data), tok); err != nil {
+		return nil, fmt.Errorf("failed to decode stored token: %w", err)
+	}
+	return tok, nil
 }
 
-// saveToken saves the OAuth token to file.
+// saveToken saves the OAuth token to the SecretStore.
 func (o *OAuthClient) saveToken(token *oauth2.Token) error {
-	// Use filepath.Dir for a robust directory extraction (avoids fragile string slicing).
-	dir := filepath.Dir(o.tokenFile)
-	if err := os.MkdirAll(dir, 0700); err != nil {
-		return fmt.Errorf("unable to create token directory: %w", err)
-	}
-
-	f, err := os.OpenFile(o.tokenFile, os.O_RDWR|os.O_CREATE|os.O_TRUNC, 0600)
+	data, err := json.Marshal(token)
 	if err != nil {
-		return fmt.Errorf("unable to create token file: %w", err)
+		return fmt.Errorf("failed to encode token: %w", err)
 	}
-	defer f.Close()
+	return o.store.Set(secrets.KeyOAuthToken, string(data))
+}
 
-	return json.NewEncoder(f).Encode(token)
+// persistingTokenSource wraps an oauth2.TokenSource and persists refreshed
+// tokens to the SecretStore. This ensures that when the oauth2 library
+// automatically refreshes an expired access token, the new token is saved
+// so it survives process restarts.
+type persistingTokenSource struct {
+	base    oauth2.TokenSource
+	store   secrets.SecretStore
+	current *oauth2.Token
+	mu      sync.Mutex
+}
+
+// Token returns the current token or refreshes it. If the token was refreshed,
+// it is persisted to the store.
+func (p *persistingTokenSource) Token() (*oauth2.Token, error) {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+
+	tok, err := p.base.Token()
+	if err != nil {
+		return nil, err
+	}
+
+	// Only persist if the token actually changed (new access token or new expiry)
+	if p.current == nil || tok.AccessToken != p.current.AccessToken {
+		data, err := json.Marshal(tok)
+		if err == nil {
+			_ = p.store.Set(secrets.KeyOAuthToken, string(data))
+		}
+		p.current = tok
+	}
+
+	return tok, nil
 }
 
 // randomState generates a cryptographically random OAuth2 state parameter.
@@ -154,7 +203,7 @@ func (o *OAuthClient) getTokenFromWeb(ctx context.Context) (*oauth2.Token, error
 	return tok, nil
 }
 
-// IsAuthenticated checks if a valid token exists.
+// IsAuthenticated checks if a valid token exists in the store.
 func (o *OAuthClient) IsAuthenticated() bool {
 	tok, err := o.loadToken()
 	if err != nil {

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -2,13 +2,24 @@
 package config
 
 import (
+	"fmt"
 	"os"
 	"path/filepath"
 	"strings"
 
+	"github.com/jflowers/gcal-organizer/internal/secrets"
 	"github.com/jflowers/gcal-organizer/internal/ux"
 	"github.com/spf13/viper"
 )
+
+// mustBindEnv wraps viper.BindEnv and panics on error. Configuration binding
+// failures indicate a programming error (typo in key name) that should be
+// caught immediately at startup.
+func mustBindEnv(args ...string) {
+	if err := viper.BindEnv(args...); err != nil {
+		panic(fmt.Sprintf("viper.BindEnv(%v) failed: %v", args, err))
+	}
+}
 
 // Config holds all configuration values for the application.
 type Config struct {
@@ -33,7 +44,7 @@ type Config struct {
 	// CredentialsFile is the path to the Google OAuth credentials file
 	CredentialsFile string
 
-	// TokenFile is the path to store OAuth tokens
+	// TokenFile is the path to store OAuth tokens (legacy, used by FileStore)
 	TokenFile string
 
 	// Verbose enables verbose output
@@ -44,6 +55,9 @@ type Config struct {
 
 	// OwnedOnly restricts mutations to files owned by the authenticated user
 	OwnedOnly bool
+
+	// NoKeyring disables OS credential store; use file-based storage
+	NoKeyring bool
 
 	// ChromeProfilePath is the path to Chrome profile for browser automation
 	ChromeProfilePath string
@@ -77,14 +91,15 @@ func Load() (*Config, error) {
 	viper.AutomaticEnv()
 
 	// Bind specific environment variables
-	viper.BindEnv("master_folder_name", "GCAL_MASTER_FOLDER_NAME")
-	viper.BindEnv("days_to_look_back", "GCAL_DAYS_TO_LOOK_BACK")
-	viper.BindEnv("filename_pattern", "GCAL_FILENAME_PATTERN")
-	viper.BindEnv("filename_keywords", "GCAL_FILENAME_KEYWORDS")
-	viper.BindEnv("gemini_api_key", "GEMINI_API_KEY")
-	viper.BindEnv("gemini_model", "GEMINI_MODEL")
-	viper.BindEnv("credentials_file", "GOOGLE_CREDENTIALS_FILE")
-	viper.BindEnv("owned-only", "GCAL_OWNED_ONLY")
+	mustBindEnv("master_folder_name", "GCAL_MASTER_FOLDER_NAME")
+	mustBindEnv("days_to_look_back", "GCAL_DAYS_TO_LOOK_BACK")
+	mustBindEnv("filename_pattern", "GCAL_FILENAME_PATTERN")
+	mustBindEnv("filename_keywords", "GCAL_FILENAME_KEYWORDS")
+	mustBindEnv("gemini_api_key", "GEMINI_API_KEY")
+	mustBindEnv("gemini_model", "GEMINI_MODEL")
+	mustBindEnv("credentials_file", "GOOGLE_CREDENTIALS_FILE")
+	mustBindEnv("owned-only", "GCAL_OWNED_ONLY")
+	mustBindEnv("no-keyring", "GCAL_NO_KEYRING")
 
 	// Override defaults with viper values
 	if v := viper.GetString("master_folder_name"); v != "" {
@@ -112,8 +127,21 @@ func Load() (*Config, error) {
 	cfg.Verbose = viper.GetBool("verbose")
 	cfg.DryRun = viper.GetBool("dry-run")
 	cfg.OwnedOnly = viper.GetBool("owned-only")
+	cfg.NoKeyring = viper.GetBool("no-keyring")
 
 	return cfg, nil
+}
+
+// LoadSecrets loads secrets from the SecretStore, overriding values from
+// environment variables when a keychain value is present. This allows
+// keychain-stored secrets to take precedence over env vars while preserving
+// env var fallback behavior.
+func (c *Config) LoadSecrets(store secrets.SecretStore) {
+	// Try to load the Gemini API key from the store. If found, it takes
+	// precedence over the env var value already loaded by Load().
+	if val, err := store.Get(secrets.KeyGeminiAPIKey); err == nil && val != "" {
+		c.GeminiAPIKey = val
+	}
 }
 
 // Validate checks that required configuration values are set.

--- a/internal/docs/service.go
+++ b/internal/docs/service.go
@@ -3,26 +3,21 @@ package docs
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"net/http"
 	"strings"
-	"time"
 	"unicode"
 
 	"github.com/jflowers/gcal-organizer/internal/retry"
+	"github.com/jflowers/gcal-organizer/pkg/models"
 	"google.golang.org/api/docs/v1"
+	"google.golang.org/api/googleapi"
 	"google.golang.org/api/option"
 )
 
 // ProcessedEmoji is the emoji used to mark processed action items.
 const ProcessedEmoji = "🆔"
-
-// ClaimEmoji is the emoji used to mark items being actively assigned.
-// Includes a timestamp for stale claim detection.
-const ClaimEmoji = "⏳"
-
-// ClaimTTL is how long a claim is valid before it's considered stale.
-const ClaimTTL = 10 * time.Minute
 
 // Service provides Google Docs operations.
 type Service struct {
@@ -45,9 +40,6 @@ type CheckboxItem struct {
 
 	// IsProcessed indicates if the item has already been processed (contains 🆔)
 	IsProcessed bool
-
-	// IsClaimed indicates if another instance has claimed this item (contains ⏳)
-	IsClaimed bool
 }
 
 // NewService creates a new Docs service.
@@ -148,9 +140,8 @@ func (s *Service) extractItemsFromSection(content []*docs.StructuralElement) ([]
 			continue
 		}
 
-		// Check if already processed or claimed
+		// Check if already processed
 		isProcessed := strings.Contains(content, ProcessedEmoji)
-		isClaimed := isClaimActive(content)
 
 		items = append(items, &CheckboxItem{
 			Text:        content,
@@ -158,7 +149,6 @@ func (s *Service) extractItemsFromSection(content []*docs.StructuralElement) ([]
 			EndIndex:    elem.EndIndex,
 			IsChecked:   false,
 			IsProcessed: isProcessed,
-			IsClaimed:   isClaimed,
 		})
 	}
 
@@ -187,33 +177,436 @@ func extractParagraphText(para *docs.Paragraph) string {
 	return strings.TrimSpace(cleaned)
 }
 
-// isClaimActive checks if a line contains an active (non-expired) ⏳ claim.
-func isClaimActive(text string) bool {
-	idx := strings.Index(text, ClaimEmoji)
-	if idx < 0 {
+// DecisionsTabTitle is the title of the Decisions tab.
+const DecisionsTabTitle = "Decisions"
+
+// contentLine represents a line of content to insert into a Decisions tab.
+type contentLine struct {
+	text      string
+	isHeading bool   // H2 heading
+	isBullet  bool   // bullet list item
+	timestamp string // if non-empty, the [HH:MM] text to link to a heading
+}
+
+// extractTranscriptContentFromDoc extracts transcript content from a document structure.
+// It looks for a tab titled "Transcript" in multi-tab docs, or uses the sole tab
+// for single-tab docs. Returns nil if no transcript content is found.
+func extractTranscriptContentFromDoc(doc *docs.Document) *models.TranscriptContent {
+	if doc == nil {
+		return nil
+	}
+
+	if len(doc.Tabs) == 0 {
+		return nil
+	}
+
+	var targetTab *docs.Tab
+
+	if len(doc.Tabs) == 1 {
+		// Single-tab doc — use the only tab
+		targetTab = doc.Tabs[0]
+	} else {
+		// Multi-tab doc — find "Transcript" tab
+		for _, tab := range doc.Tabs {
+			if tab.TabProperties != nil && tab.TabProperties.Title == "Transcript" {
+				targetTab = tab
+				break
+			}
+		}
+	}
+
+	if targetTab == nil {
+		return nil
+	}
+
+	if targetTab.DocumentTab == nil || targetTab.DocumentTab.Body == nil {
+		return nil
+	}
+
+	tabID := ""
+	if targetTab.TabProperties != nil {
+		tabID = targetTab.TabProperties.TabId
+	}
+
+	tc := &models.TranscriptContent{
+		TabID: tabID,
+	}
+
+	var fullText strings.Builder
+	for _, elem := range targetTab.DocumentTab.Body.Content {
+		if elem.Paragraph == nil {
+			continue
+		}
+
+		paraText := extractParagraphText(elem.Paragraph)
+
+		fullText.WriteString(paraText)
+		// Re-add the newline that extractParagraphText may have stripped
+		if !strings.HasSuffix(paraText, "\n") {
+			fullText.WriteString("\n")
+		}
+
+		// Check for H3 headings with HeadingId
+		if elem.Paragraph.ParagraphStyle != nil &&
+			elem.Paragraph.ParagraphStyle.NamedStyleType == "HEADING_3" &&
+			elem.Paragraph.ParagraphStyle.HeadingId != "" {
+			tc.Headings = append(tc.Headings, models.TranscriptHeading{
+				HeadingID: elem.Paragraph.ParagraphStyle.HeadingId,
+				Text:      strings.TrimSpace(paraText),
+				Index:     elem.StartIndex,
+			})
+		}
+	}
+
+	tc.FullText = fullText.String()
+	return tc
+}
+
+// ExtractTranscriptContent retrieves a document and extracts transcript content.
+func (s *Service) ExtractTranscriptContent(ctx context.Context, docID string) (*models.TranscriptContent, error) {
+	var doc *docs.Document
+	err := retry.Do(ctx, retry.DefaultConfig(), func() error {
+		var e error
+		doc, e = s.client.Documents.Get(docID).IncludeTabsContent(true).Context(ctx).Do()
+		return e
+	})
+	if err != nil {
+		return nil, fmt.Errorf("failed to get document for transcript extraction: %w", err)
+	}
+
+	return extractTranscriptContentFromDoc(doc), nil
+}
+
+// hasDecisionsTabInDoc checks if a document structure contains a "Decisions" tab.
+func hasDecisionsTabInDoc(doc *docs.Document) bool {
+	if doc == nil {
 		return false
 	}
-
-	// Extract the timestamp after ⏳
-	after := text[idx+len(ClaimEmoji):]
-	// Trim any trailing whitespace or characters
-	after = strings.TrimSpace(after)
-	if after == "" {
-		// Claim with no timestamp — treat as active (conservative)
-		return true
+	for _, tab := range doc.Tabs {
+		if tab.TabProperties != nil && tab.TabProperties.Title == DecisionsTabTitle {
+			return true
+		}
 	}
+	return false
+}
 
-	// Try to parse RFC3339 timestamp
-	// Take first 20 chars max (length of 2026-02-09T12:38:10Z)
-	if len(after) > 25 {
-		after = after[:25]
-	}
-	claimTime, err := time.Parse(time.RFC3339, after)
+// HasDecisionsTab checks if a document already has a "Decisions" tab.
+func (s *Service) HasDecisionsTab(ctx context.Context, docID string) (bool, error) {
+	var doc *docs.Document
+	err := retry.Do(ctx, retry.DefaultConfig(), func() error {
+		var e error
+		doc, e = s.client.Documents.Get(docID).Context(ctx).Do()
+		return e
+	})
 	if err != nil {
-		// Can't parse timestamp — treat as active (conservative)
-		return true
+		return false, fmt.Errorf("failed to get document for decisions tab check: %w", err)
 	}
 
-	// Check if claim has expired
-	return time.Since(claimTime) < ClaimTTL
+	return hasDecisionsTabInDoc(doc), nil
+}
+
+// matchTimestampToHeading finds the transcript heading that best matches a decision's timestamp.
+// Returns nil if no headings exist or timestamp is empty.
+func matchTimestampToHeading(timestamp string, headings []models.TranscriptHeading) *models.TranscriptHeading {
+	if timestamp == "" || len(headings) == 0 {
+		return nil
+	}
+
+	// First try exact match: heading text contains the timestamp
+	for i := range headings {
+		if strings.Contains(headings[i].Text, timestamp) {
+			return &headings[i]
+		}
+	}
+
+	// No exact match — find nearest heading by comparing timestamps
+	// Parse decision timestamp as minutes since midnight for comparison
+	decMinutes := parseTimestampMinutes(timestamp)
+	if decMinutes < 0 {
+		// Can't parse, return first heading as fallback
+		return &headings[0]
+	}
+
+	// Find the nearest preceding heading (or first if timestamp is before all)
+	var best *models.TranscriptHeading
+	bestMinutes := -1
+
+	for i := range headings {
+		hMinutes := parseTimestampMinutes(headings[i].Text)
+		if hMinutes < 0 {
+			continue
+		}
+
+		if hMinutes <= decMinutes {
+			if best == nil || hMinutes > bestMinutes {
+				best = &headings[i]
+				bestMinutes = hMinutes
+			}
+		}
+	}
+
+	if best != nil {
+		return best
+	}
+
+	// Timestamp is before all headings — return the first heading
+	// Or timestamp is after all headings — return the last heading
+	if decMinutes < parseTimestampMinutes(headings[0].Text) {
+		return &headings[0]
+	}
+	return &headings[len(headings)-1]
+}
+
+// parseTimestampMinutes parses "HH:MM" format and returns minutes since midnight.
+// Returns -1 if parsing fails.
+// Operates on the byte representation but validates that each character is an
+// ASCII digit before arithmetic, making it safe for strings that contain
+// multi-byte UTF-8 characters before the timestamp.
+func parseTimestampMinutes(ts string) int {
+	// Convert to bytes explicitly for safe indexing
+	b := []byte(ts)
+	for i := 0; i+4 < len(b); i++ {
+		if b[i+2] != ':' {
+			continue
+		}
+		h1, h2 := b[i], b[i+1]
+		m1, m2 := b[i+3], b[i+4]
+		// Verify all four positions are ASCII digits
+		if h1 < '0' || h1 > '9' || h2 < '0' || h2 > '9' ||
+			m1 < '0' || m1 > '5' || m2 < '0' || m2 > '9' {
+			continue
+		}
+		hours := int(h1-'0')*10 + int(h2-'0')
+		minutes := int(m1-'0')*10 + int(m2-'0')
+		if hours <= 23 && minutes <= 59 {
+			return hours*60 + minutes
+		}
+	}
+	return -1
+}
+
+// utf16Len returns the number of UTF-16 code units needed to represent s.
+// Google Docs API indices are measured in UTF-16 code units, not bytes or runes.
+func utf16Len(s string) int64 {
+	var n int64
+	for _, r := range s {
+		if r >= 0x10000 {
+			n += 2 // surrogate pair
+		} else {
+			n++
+		}
+	}
+	return n
+}
+
+// ErrDecisionsTabExists is returned when trying to create a Decisions tab that already exists.
+var ErrDecisionsTabExists = errors.New("decisions tab already exists")
+
+// buildAddTabRequest creates a BatchUpdate request to add a new tab.
+func buildAddTabRequest(title string) *docs.Request {
+	return &docs.Request{
+		AddDocumentTab: &docs.AddDocumentTabRequest{
+			TabProperties: &docs.TabProperties{
+				Title: title,
+			},
+		},
+	}
+}
+
+// buildDecisionsContent constructs the content lines for the Decisions tab.
+func buildDecisionsContent(decisions []models.Decision) []contentLine {
+	var lines []contentLine
+
+	// Section headings
+	sections := []struct {
+		heading  string
+		category string
+	}{
+		{"Decisions Made", "made"},
+		{"Decisions Deferred", "deferred"},
+		{"Open Items", "open"},
+	}
+
+	hasAnyDecisions := len(decisions) > 0
+
+	for _, section := range sections {
+		lines = append(lines, contentLine{text: section.heading, isHeading: true})
+
+		found := false
+		if hasAnyDecisions {
+			for _, d := range decisions {
+				if d.Category == section.category {
+					bulletText := d.Text
+					ts := ""
+					if d.Timestamp != "" {
+						bulletText = fmt.Sprintf("[%s] %s", d.Timestamp, d.Text)
+						ts = d.Timestamp
+					}
+					lines = append(lines, contentLine{text: bulletText, isBullet: true, timestamp: ts})
+					found = true
+				}
+			}
+		}
+
+		if !found {
+			lines = append(lines, contentLine{text: "No decisions identified", isBullet: false})
+		}
+	}
+
+	return lines
+}
+
+// CreateDecisionsTab creates a new "Decisions" tab in a document with categorized decisions.
+func (s *Service) CreateDecisionsTab(ctx context.Context, docID string, decisions []models.Decision, transcript *models.TranscriptContent) error {
+	// BatchUpdate #1: Create the Decisions tab
+	addTabReq := buildAddTabRequest(DecisionsTabTitle)
+
+	var batchResp *docs.BatchUpdateDocumentResponse
+	err := retry.Do(ctx, retry.DefaultConfig(), func() error {
+		var e error
+		batchResp, e = s.client.Documents.BatchUpdate(docID, &docs.BatchUpdateDocumentRequest{
+			Requests: []*docs.Request{addTabReq},
+		}).Context(ctx).Do()
+		return e
+	})
+	if err != nil {
+		// Check if the error indicates a duplicate tab (optimistic concurrency).
+		// Use structured error inspection via googleapi.Error when possible.
+		var apiErr *googleapi.Error
+		if errors.As(err, &apiErr) {
+			if apiErr.Code == 409 || strings.Contains(apiErr.Message, "already exists") || strings.Contains(apiErr.Message, "duplicate") {
+				return ErrDecisionsTabExists
+			}
+		} else if strings.Contains(err.Error(), "already exists") || strings.Contains(err.Error(), "duplicate") {
+			return ErrDecisionsTabExists
+		}
+		return fmt.Errorf("failed to create Decisions tab: %w", err)
+	}
+
+	// Extract the new tab ID from the response
+	var newTabID string
+	if batchResp != nil {
+		for _, reply := range batchResp.Replies {
+			if reply.AddDocumentTab != nil && reply.AddDocumentTab.TabProperties != nil {
+				newTabID = reply.AddDocumentTab.TabProperties.TabId
+				break
+			}
+		}
+	}
+	if newTabID == "" {
+		return fmt.Errorf("no TabId returned from AddDocumentTab response")
+	}
+
+	// Build content for the Decisions tab
+	content := buildDecisionsContent(decisions)
+
+	// BatchUpdate #2: Insert content into the new tab
+	var requests []*docs.Request
+
+	// Build text content — insert from bottom to top so indices don't shift.
+	// Google Docs new tab starts with index 1 (empty paragraph).
+	// We insert all text at index 1 in reverse order.
+	var fullText strings.Builder
+	for _, line := range content {
+		fullText.WriteString(line.text)
+		fullText.WriteString("\n")
+	}
+
+	// Insert all text at once at position 1
+	textToInsert := fullText.String()
+	if textToInsert != "" {
+		requests = append(requests, &docs.Request{
+			InsertText: &docs.InsertTextRequest{
+				Text: textToInsert,
+				Location: &docs.Location{
+					Index: 1,
+					TabId: newTabID,
+				},
+			},
+		})
+	}
+
+	// Now apply styles — calculate positions based on inserted text.
+	// Google Docs API uses UTF-16 code unit indices, not byte indices.
+	offset := int64(1) // Starting position after insert
+	for _, line := range content {
+		lineLen := utf16Len(line.text) + 1 // +1 for newline
+		startIdx := offset
+		endIdx := offset + lineLen
+
+		if line.isHeading {
+			requests = append(requests, &docs.Request{
+				UpdateParagraphStyle: &docs.UpdateParagraphStyleRequest{
+					Range: &docs.Range{
+						StartIndex: startIdx,
+						EndIndex:   endIdx,
+						TabId:      newTabID,
+					},
+					ParagraphStyle: &docs.ParagraphStyle{
+						NamedStyleType: "HEADING_2",
+					},
+					Fields: "namedStyleType",
+				},
+			})
+		}
+
+		if line.isBullet {
+			requests = append(requests, &docs.Request{
+				CreateParagraphBullets: &docs.CreateParagraphBulletsRequest{
+					Range: &docs.Range{
+						StartIndex: startIdx,
+						EndIndex:   endIdx,
+						TabId:      newTabID,
+					},
+					BulletPreset: "BULLET_DISC_CIRCLE_SQUARE",
+				},
+			})
+
+			// Add cross-tab heading link for timestamp text (US2 — FR-012)
+			if line.timestamp != "" && transcript != nil && len(transcript.Headings) > 0 {
+				heading := matchTimestampToHeading(line.timestamp, transcript.Headings)
+				if heading != nil {
+					// The timestamp text is formatted as "[HH:MM]" at the start of the line
+					tsText := fmt.Sprintf("[%s]", line.timestamp)
+					tsEndIdx := startIdx + utf16Len(tsText)
+					if tsEndIdx <= endIdx {
+						requests = append(requests, &docs.Request{
+							UpdateTextStyle: &docs.UpdateTextStyleRequest{
+								Range: &docs.Range{
+									StartIndex: startIdx,
+									EndIndex:   tsEndIdx,
+									TabId:      newTabID,
+								},
+								TextStyle: &docs.TextStyle{
+									Link: &docs.Link{
+										Heading: &docs.HeadingLink{
+											Id:    heading.HeadingID,
+											TabId: transcript.TabID,
+										},
+									},
+								},
+								Fields: "link",
+							},
+						})
+					}
+				}
+			}
+		}
+
+		offset += lineLen
+	}
+
+	if len(requests) > 0 {
+		err = retry.Do(ctx, retry.DefaultConfig(), func() error {
+			_, e := s.client.Documents.BatchUpdate(docID, &docs.BatchUpdateDocumentRequest{
+				Requests: requests,
+			}).Context(ctx).Do()
+			return e
+		})
+		if err != nil {
+			return fmt.Errorf("failed to insert content into Decisions tab: %w", err)
+		}
+	}
+
+	return nil
 }

--- a/internal/docs/service_test.go
+++ b/internal/docs/service_test.go
@@ -1,0 +1,499 @@
+package docs
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/jflowers/gcal-organizer/pkg/models"
+	"google.golang.org/api/docs/v1"
+)
+
+// ---------- T010: ExtractTranscriptContent tests ----------
+
+// buildTestDoc creates a docs.Document with the given tabs for testing.
+func buildTestDoc(tabs []*docs.Tab) *docs.Document {
+	return &docs.Document{
+		DocumentId: "test-doc-id",
+		Tabs:       tabs,
+	}
+}
+
+// buildTab creates a tab with title, content elements, and a tabID.
+func buildTab(title, tabID string, elements []*docs.StructuralElement) *docs.Tab {
+	return &docs.Tab{
+		TabProperties: &docs.TabProperties{
+			Title: title,
+			TabId: tabID,
+		},
+		DocumentTab: &docs.DocumentTab{
+			Body: &docs.Body{
+				Content: elements,
+			},
+		},
+	}
+}
+
+// buildParagraphElement creates a structural element with paragraph text and optional heading style.
+func buildParagraphElement(text string, startIndex, endIndex int64, headingStyle string, headingID string) *docs.StructuralElement {
+	para := &docs.Paragraph{
+		Elements: []*docs.ParagraphElement{
+			{
+				TextRun: &docs.TextRun{
+					Content: text,
+				},
+			},
+		},
+		ParagraphStyle: &docs.ParagraphStyle{},
+	}
+	if headingStyle != "" {
+		para.ParagraphStyle.NamedStyleType = headingStyle
+	}
+	if headingID != "" {
+		para.ParagraphStyle.HeadingId = headingID
+	}
+
+	return &docs.StructuralElement{
+		StartIndex: startIndex,
+		EndIndex:   endIndex,
+		Paragraph:  para,
+	}
+}
+
+func TestExtractTranscriptContent(t *testing.T) {
+	tests := []struct {
+		name             string
+		doc              *docs.Document
+		wantTabID        string
+		wantFullText     string
+		wantHeadingCount int
+		wantNil          bool
+	}{
+		{
+			name: "finds Transcript tab in multi-tab doc",
+			doc: buildTestDoc([]*docs.Tab{
+				buildTab("Notes", "tab-notes", []*docs.StructuralElement{
+					buildParagraphElement("Some notes\n", 0, 11, "", ""),
+				}),
+				buildTab("Transcript", "tab-transcript", []*docs.StructuralElement{
+					buildParagraphElement("12:00\n", 0, 6, "HEADING_3", "h.abc123"),
+					buildParagraphElement("Hello everyone\n", 6, 21, "", ""),
+					buildParagraphElement("12:15\n", 21, 27, "HEADING_3", "h.def456"),
+					buildParagraphElement("Moving on to the next topic\n", 27, 55, "", ""),
+				}),
+			}),
+			wantTabID:        "tab-transcript",
+			wantFullText:     "12:00\nHello everyone\n12:15\nMoving on to the next topic\n",
+			wantHeadingCount: 2,
+		},
+		{
+			name: "uses first tab content for single-tab doc",
+			doc: buildTestDoc([]*docs.Tab{
+				buildTab("", "tab-only", []*docs.StructuralElement{
+					buildParagraphElement("10:00\n", 0, 6, "HEADING_3", "h.single1"),
+					buildParagraphElement("Discussion content\n", 6, 25, "", ""),
+				}),
+			}),
+			wantTabID:        "tab-only",
+			wantFullText:     "10:00\nDiscussion content\n",
+			wantHeadingCount: 1,
+		},
+		{
+			name: "returns empty TranscriptContent for doc with no transcript",
+			doc: buildTestDoc([]*docs.Tab{
+				buildTab("Notes", "tab-notes", []*docs.StructuralElement{
+					buildParagraphElement("Some notes\n", 0, 11, "", ""),
+				}),
+				buildTab("Action Items", "tab-actions", []*docs.StructuralElement{
+					buildParagraphElement("Do something\n", 0, 13, "", ""),
+				}),
+			}),
+			wantNil: true,
+		},
+		{
+			name: "extracts H3 heading metadata",
+			doc: buildTestDoc([]*docs.Tab{
+				buildTab("Transcript", "tab-t", []*docs.StructuralElement{
+					buildParagraphElement("09:30\n", 0, 6, "HEADING_3", "h.head1"),
+					buildParagraphElement("Content here\n", 6, 19, "", ""),
+					buildParagraphElement("09:45\n", 19, 25, "HEADING_3", "h.head2"),
+					buildParagraphElement("More content\n", 25, 38, "", ""),
+					buildParagraphElement("10:00\n", 38, 44, "HEADING_3", "h.head3"),
+				}),
+			}),
+			wantTabID:        "tab-t",
+			wantHeadingCount: 3,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := extractTranscriptContentFromDoc(tt.doc)
+
+			if tt.wantNil {
+				if result != nil {
+					t.Errorf("expected nil TranscriptContent, got %+v", result)
+				}
+				return
+			}
+
+			if result == nil {
+				t.Fatal("expected non-nil TranscriptContent, got nil")
+			}
+
+			if result.TabID != tt.wantTabID {
+				t.Errorf("TabID: got %q, want %q", result.TabID, tt.wantTabID)
+			}
+
+			if tt.wantFullText != "" && result.FullText != tt.wantFullText {
+				t.Errorf("FullText: got %q, want %q", result.FullText, tt.wantFullText)
+			}
+
+			if len(result.Headings) != tt.wantHeadingCount {
+				t.Errorf("Headings count: got %d, want %d", len(result.Headings), tt.wantHeadingCount)
+			}
+		})
+	}
+}
+
+// ---------- T011: CreateDecisionsTab tests ----------
+
+func TestCreateDecisionsTab_RequestStructure(t *testing.T) {
+	// Test that CreateDecisionsTab builds correct batch update requests.
+	// Since we can't easily test actual API calls, we test the request building logic.
+
+	tests := []struct {
+		name       string
+		decisions  []models.Decision
+		transcript *models.TranscriptContent
+		wantTitle  string
+	}{
+		{
+			name: "creates tab with correct title",
+			decisions: []models.Decision{
+				{Category: "made", Text: "Adopt new pipeline", Timestamp: "12:34"},
+			},
+			transcript: &models.TranscriptContent{
+				TabID:    "tab-transcript",
+				FullText: "Some transcript text",
+			},
+			wantTitle: "Decisions",
+		},
+		{
+			name:      "handles empty decisions list",
+			decisions: []models.Decision{},
+			transcript: &models.TranscriptContent{
+				TabID:    "tab-transcript",
+				FullText: "Some transcript text",
+			},
+			wantTitle: "Decisions",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Test the request building helper
+			req := buildAddTabRequest(tt.wantTitle)
+			if req.AddDocumentTab == nil {
+				t.Fatal("expected AddDocumentTab request")
+			}
+			if req.AddDocumentTab.TabProperties.Title != tt.wantTitle {
+				t.Errorf("tab title: got %q, want %q", req.AddDocumentTab.TabProperties.Title, tt.wantTitle)
+			}
+		})
+	}
+}
+
+func TestBuildDecisionsContent(t *testing.T) {
+	tests := []struct {
+		name           string
+		decisions      []models.Decision
+		wantSections   int
+		wantContains   []string
+		wantNoDecision bool
+	}{
+		{
+			name: "three categorized sections with decisions",
+			decisions: []models.Decision{
+				{Category: "made", Text: "Adopt new pipeline", Timestamp: "12:34"},
+				{Category: "deferred", Text: "Budget review", Timestamp: "13:00"},
+				{Category: "open", Text: "API migration", Timestamp: "13:45"},
+			},
+			wantSections: 3,
+			wantContains: []string{"Decisions Made", "Decisions Deferred", "Open Items", "Adopt new pipeline", "Budget review", "API migration"},
+		},
+		{
+			name:           "empty decisions shows no decisions note",
+			decisions:      []models.Decision{},
+			wantSections:   3,
+			wantContains:   []string{"Decisions Made", "Decisions Deferred", "Open Items", "No decisions identified"},
+			wantNoDecision: true,
+		},
+		{
+			name: "decisions in single category - empty sections get placeholder",
+			decisions: []models.Decision{
+				{Category: "made", Text: "First decision"},
+				{Category: "made", Text: "Second decision"},
+			},
+			wantSections: 3,
+			wantContains: []string{"First decision", "Second decision", "No decisions identified"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			content := buildDecisionsContent(tt.decisions)
+
+			for _, want := range tt.wantContains {
+				found := false
+				for _, line := range content {
+					if strings.Contains(line.text, want) {
+						found = true
+						break
+					}
+				}
+				if !found {
+					t.Errorf("expected content to contain %q", want)
+				}
+			}
+		})
+	}
+}
+
+// Verify the extractTranscriptContentFromDoc function is accessible (compile check)
+func TestExtractTranscriptContentFromDoc_NilDoc(t *testing.T) {
+	result := extractTranscriptContentFromDoc(nil)
+	if result != nil {
+		t.Errorf("expected nil for nil doc, got %+v", result)
+	}
+}
+
+// Verify buildAddTabRequest exists and returns correct structure
+func TestBuildAddTabRequest(t *testing.T) {
+	req := buildAddTabRequest("Decisions")
+	if req.AddDocumentTab == nil {
+		t.Fatal("expected AddDocumentTab to be non-nil")
+	}
+	if req.AddDocumentTab.TabProperties == nil {
+		t.Fatal("expected TabProperties to be non-nil")
+	}
+	if req.AddDocumentTab.TabProperties.Title != "Decisions" {
+		t.Errorf("expected title 'Decisions', got %q", req.AddDocumentTab.TabProperties.Title)
+	}
+}
+
+// Compile-time check that Service implements the expected interface methods.
+var _ = (*Service)(nil)
+
+// ---------- T024: HasDecisionsTab tests ----------
+
+func TestHasDecisionsTab(t *testing.T) {
+	tests := []struct {
+		name    string
+		doc     *docs.Document
+		wantHas bool
+	}{
+		{
+			name: "returns true when Decisions tab exists",
+			doc: buildTestDoc([]*docs.Tab{
+				buildTab("Notes", "tab-notes", nil),
+				buildTab("Decisions", "tab-decisions", nil),
+			}),
+			wantHas: true,
+		},
+		{
+			name: "returns false when no Decisions tab",
+			doc: buildTestDoc([]*docs.Tab{
+				buildTab("Notes", "tab-notes", nil),
+				buildTab("Transcript", "tab-transcript", nil),
+			}),
+			wantHas: false,
+		},
+		{
+			name: "returns true for manually-created Decisions tab",
+			doc: buildTestDoc([]*docs.Tab{
+				buildTab("Decisions", "tab-manual-decisions", nil),
+			}),
+			wantHas: true,
+		},
+		{
+			name:    "returns false for empty tabs",
+			doc:     buildTestDoc([]*docs.Tab{}),
+			wantHas: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := hasDecisionsTabInDoc(tt.doc)
+			if got != tt.wantHas {
+				t.Errorf("hasDecisionsTabInDoc: got %v, want %v", got, tt.wantHas)
+			}
+		})
+	}
+}
+
+// ---------- T025: Optimistic concurrency tests ----------
+
+func TestErrDecisionsTabExists(t *testing.T) {
+	// Verify that the sentinel error exists and has the expected message
+	if ErrDecisionsTabExists == nil {
+		t.Fatal("ErrDecisionsTabExists should not be nil")
+	}
+	if ErrDecisionsTabExists.Error() != "decisions tab already exists" {
+		t.Errorf("expected error message 'decisions tab already exists', got %q", ErrDecisionsTabExists.Error())
+	}
+}
+
+// ---------- parseTimestampMinutes tests ----------
+
+func TestParseTimestampMinutes(t *testing.T) {
+	tests := []struct {
+		name string
+		ts   string
+		want int
+	}{
+		{"standard time", "12:34", 754},
+		{"midnight", "00:00", 0},
+		{"end of day", "23:59", 1439},
+		{"morning", "09:00", 540},
+		{"embedded in text", "Meeting at 10:30 today", 630},
+		{"empty string", "", -1},
+		{"invalid", "not a time", -1},
+		{"too short", "12:", -1},
+		{"just digits", "1234", -1},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := parseTimestampMinutes(tt.ts)
+			if got != tt.want {
+				t.Errorf("parseTimestampMinutes(%q): got %d, want %d", tt.ts, got, tt.want)
+			}
+		})
+	}
+}
+
+// ---------- T019: Timestamp to heading matching tests ----------
+
+func TestTimestampToHeadingMatch(t *testing.T) {
+	headings := []models.TranscriptHeading{
+		{HeadingID: "h.head1", Text: "09:30", Index: 0},
+		{HeadingID: "h.head2", Text: "09:45", Index: 19},
+		{HeadingID: "h.head3", Text: "10:00", Index: 38},
+		{HeadingID: "h.head4", Text: "10:15", Index: 57},
+	}
+
+	tests := []struct {
+		name          string
+		timestamp     string
+		headings      []models.TranscriptHeading
+		wantHeadingID string
+		wantNil       bool
+	}{
+		{
+			name:          "exact timestamp match returns correct HeadingID",
+			timestamp:     "09:45",
+			headings:      headings,
+			wantHeadingID: "h.head2",
+		},
+		{
+			name:          "nearest preceding heading when no exact match",
+			timestamp:     "09:50",
+			headings:      headings,
+			wantHeadingID: "h.head2", // 09:45 is nearest preceding
+		},
+		{
+			name:      "no headings returns nil",
+			timestamp: "10:00",
+			headings:  nil,
+			wantNil:   true,
+		},
+		{
+			name:      "empty headings returns nil",
+			timestamp: "10:00",
+			headings:  []models.TranscriptHeading{},
+			wantNil:   true,
+		},
+		{
+			name:          "exact match at first heading",
+			timestamp:     "09:30",
+			headings:      headings,
+			wantHeadingID: "h.head1",
+		},
+		{
+			name:          "exact match at last heading",
+			timestamp:     "10:15",
+			headings:      headings,
+			wantHeadingID: "h.head4",
+		},
+		{
+			name:          "timestamp before any heading uses first heading",
+			timestamp:     "08:00",
+			headings:      headings,
+			wantHeadingID: "h.head1",
+		},
+		{
+			name:          "timestamp after all headings uses last heading",
+			timestamp:     "11:00",
+			headings:      headings,
+			wantHeadingID: "h.head4",
+		},
+		{
+			name:      "empty timestamp returns nil",
+			timestamp: "",
+			headings:  headings,
+			wantNil:   true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := matchTimestampToHeading(tt.timestamp, tt.headings)
+
+			if tt.wantNil {
+				if result != nil {
+					t.Errorf("expected nil, got %+v", result)
+				}
+				return
+			}
+
+			if result == nil {
+				t.Fatal("expected non-nil result, got nil")
+			}
+
+			if result.HeadingID != tt.wantHeadingID {
+				t.Errorf("HeadingID: got %q, want %q", result.HeadingID, tt.wantHeadingID)
+			}
+		})
+	}
+}
+
+// ---------- T020: CreateDecisionsTab with links tests ----------
+
+func TestBuildDecisionsContentWithTimestamp(t *testing.T) {
+	// Verify that timestamps are included in decision bullet text
+	decisions := []models.Decision{
+		{Category: "made", Text: "Adopt new pipeline", Timestamp: "12:34"},
+		{Category: "made", Text: "No timestamp decision", Timestamp: ""},
+	}
+
+	content := buildDecisionsContent(decisions)
+
+	foundWithTimestamp := false
+	foundWithout := false
+	for _, line := range content {
+		if strings.Contains(line.text, "[12:34]") && strings.Contains(line.text, "Adopt new pipeline") {
+			foundWithTimestamp = true
+		}
+		if line.text == "No timestamp decision" {
+			foundWithout = true
+		}
+	}
+
+	if !foundWithTimestamp {
+		t.Error("expected decision with timestamp formatted as '[12:34] Adopt new pipeline'")
+	}
+	if !foundWithout {
+		t.Error("expected decision without timestamp to have plain text")
+	}
+}

--- a/internal/drive/service.go
+++ b/internal/drive/service.go
@@ -3,6 +3,7 @@ package drive
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"net/http"
 	"regexp"
@@ -13,6 +14,7 @@ import (
 	"github.com/jflowers/gcal-organizer/internal/retry"
 	"github.com/jflowers/gcal-organizer/pkg/models"
 	"google.golang.org/api/drive/v3"
+	"google.golang.org/api/googleapi"
 	"google.golang.org/api/option"
 )
 
@@ -462,13 +464,18 @@ func (s *Service) CreateShortcut(ctx context.Context, fileID, fileName, targetFo
 		return e
 	})
 	if err != nil {
-		// Include file URL for requesting access if permission denied
+		// Include file URL for requesting access if permission denied.
+		// Use structured error inspection via googleapi.Error when possible.
 		fileURL := fmt.Sprintf("https://drive.google.com/file/d/%s/view", fileID)
 		reason := fmt.Sprintf("error: %v", err)
-		if strings.Contains(err.Error(), "403") || strings.Contains(err.Error(), "forbidden") || strings.Contains(err.Error(), "permission") {
-			reason = fmt.Sprintf("Permission denied. Request access: %s", fileURL)
-		} else if strings.Contains(err.Error(), "404") || strings.Contains(err.Error(), "notFound") {
-			reason = fmt.Sprintf("File not found or deleted: %s", fileURL)
+		var apiErr *googleapi.Error
+		if errors.As(err, &apiErr) {
+			switch apiErr.Code {
+			case 403:
+				reason = fmt.Sprintf("Permission denied. Request access: %s", fileURL)
+			case 404:
+				reason = fmt.Sprintf("File not found or deleted: %s", fileURL)
+			}
 		}
 		return ActionResult{
 			Action:  "shortcut",

--- a/internal/gemini/client.go
+++ b/internal/gemini/client.go
@@ -9,6 +9,7 @@ import (
 	"strings"
 
 	"github.com/jflowers/gcal-organizer/internal/retry"
+	"github.com/jflowers/gcal-organizer/pkg/models"
 	"google.golang.org/genai"
 )
 
@@ -111,7 +112,9 @@ Your response:`, itemsList.String())
 		return nil, fmt.Errorf("Gemini API error: %w", err)
 	}
 
-	if len(result.Candidates) == 0 || len(result.Candidates[0].Content.Parts) == 0 {
+	if len(result.Candidates) == 0 ||
+		result.Candidates[0].Content == nil ||
+		len(result.Candidates[0].Content.Parts) == 0 {
 		return nil, fmt.Errorf("no response from Gemini")
 	}
 
@@ -130,6 +133,126 @@ Your response:`, itemsList.String())
 	}
 
 	return assignments, nil
+}
+
+// ExtractDecisions sends a transcript to Gemini and returns structured decisions.
+func (c *Client) ExtractDecisions(ctx context.Context, transcriptText string) ([]models.Decision, error) {
+	if transcriptText == "" {
+		return nil, nil
+	}
+
+	prompt := fmt.Sprintf(`You are a meeting decision extraction assistant. Analyze the following meeting transcript and extract all decisions into three categories:
+
+1. "made" — Decisions that were explicitly agreed upon or committed to
+2. "deferred" — Decisions that were explicitly postponed or tabled for later
+3. "open" — Topics discussed but left unresolved, needing further discussion
+
+For each decision, provide:
+- "category": one of "made", "deferred", or "open"
+- "text": a clear, concise description of the decision (one sentence)
+- "timestamp": the HH:MM timestamp from the transcript where this was discussed (or empty string if not identifiable)
+- "context": a brief excerpt from the transcript providing context (or empty string)
+
+Return ONLY a JSON array. No other text.
+
+Example response:
+[
+  {"category": "made", "text": "Team will adopt GitHub Actions for CI/CD", "timestamp": "12:34", "context": "After discussing three options, team voted unanimously"},
+  {"category": "deferred", "text": "Budget allocation for Q3", "timestamp": "13:15", "context": "Waiting for finance team input"},
+  {"category": "open", "text": "Whether to migrate to new API version", "timestamp": "13:45", "context": "Need performance benchmarks first"}
+]
+
+If no decisions are found, return an empty array: []
+
+Transcript:
+%s`, transcriptText)
+
+	var result *genai.GenerateContentResponse
+	err := retry.Do(ctx, retry.DefaultConfig(), func() error {
+		var e error
+		result, e = c.client.Models.GenerateContent(ctx, c.modelName, genai.Text(prompt), nil)
+		return e
+	})
+	if err != nil {
+		return nil, fmt.Errorf("Gemini API error: %w", err)
+	}
+
+	if len(result.Candidates) == 0 ||
+		result.Candidates[0].Content == nil ||
+		len(result.Candidates[0].Content.Parts) == 0 {
+		return nil, fmt.Errorf("no response from Gemini")
+	}
+
+	var responseText string
+	for _, part := range result.Candidates[0].Content.Parts {
+		if part.Text != "" {
+			responseText += part.Text
+		}
+	}
+
+	decisions, err := parseDecisionsResponse(responseText)
+	if err != nil {
+		return nil, err
+	}
+
+	return decisions, nil
+}
+
+// parseDecisionsResponse parses the JSON array response from Gemini for decision extraction.
+func parseDecisionsResponse(responseText string) ([]models.Decision, error) {
+	responseText = strings.TrimSpace(responseText)
+	responseText = strings.TrimPrefix(responseText, "```json")
+	responseText = strings.TrimPrefix(responseText, "```")
+	responseText = strings.TrimSuffix(responseText, "```")
+	responseText = strings.TrimSpace(responseText)
+
+	// Try to find JSON array in the response
+	jsonArrayRegex := regexp.MustCompile(`\[[\s\S]*\]`)
+	matches := jsonArrayRegex.FindString(responseText)
+	if matches != "" {
+		responseText = matches
+	}
+
+	var rawDecisions []struct {
+		Category  string `json:"category"`
+		Text      string `json:"text"`
+		Timestamp string `json:"timestamp"`
+		Context   string `json:"context"`
+	}
+
+	if err := json.Unmarshal([]byte(responseText), &rawDecisions); err != nil {
+		// Do not include raw response text in error — it may contain
+		// confidential transcript content from the meeting.
+		return nil, fmt.Errorf("failed to parse Gemini decisions response as JSON array: %w", err)
+	}
+
+	validCategories := map[string]bool{
+		"made":     true,
+		"deferred": true,
+		"open":     true,
+	}
+
+	var decisions []models.Decision
+	for _, raw := range rawDecisions {
+		text := strings.TrimSpace(raw.Text)
+		if text == "" {
+			continue
+		}
+
+		category := strings.ToLower(strings.TrimSpace(raw.Category))
+		if !validCategories[category] {
+			category = "open"
+		}
+
+		decisions = append(decisions, models.Decision{
+			Category:  category,
+			Text:      text,
+			Timestamp: strings.TrimSpace(raw.Timestamp),
+			Context:   strings.TrimSpace(raw.Context),
+		})
+	}
+
+	return decisions, nil
 }
 
 // parseAssignmentsResponse parses the JSON array response from Gemini.
@@ -154,7 +277,9 @@ func parseAssignmentsResponse(responseText string, items []CheckboxItem) ([]Chec
 	}
 
 	if err := json.Unmarshal([]byte(responseText), &rawAssignments); err != nil {
-		return nil, fmt.Errorf("failed to parse Gemini response as JSON array: %w\nResponse was: %s", err, responseText)
+		// Do not include raw response text in error — it may contain
+		// confidential task content from the meeting document.
+		return nil, fmt.Errorf("failed to parse Gemini response as JSON array: %w", err)
 	}
 
 	// Map items by index for easy lookup

--- a/internal/gemini/client_test.go
+++ b/internal/gemini/client_test.go
@@ -2,6 +2,8 @@ package gemini
 
 import (
 	"testing"
+
+	"github.com/jflowers/gcal-organizer/pkg/models"
 )
 
 func TestParseAssignmentsResponse(t *testing.T) {
@@ -61,5 +63,115 @@ func TestParseAssignmentsResponse(t *testing.T) {
 				t.Errorf("got %d assignments, want %d", len(result), tt.wantCount)
 			}
 		})
+	}
+}
+
+// ---------- T005: Decision extraction response parsing tests ----------
+
+func TestParseDecisionsResponse(t *testing.T) {
+	tests := []struct {
+		name           string
+		response       string
+		wantCount      int
+		wantError      bool
+		wantCategories []string
+		wantTexts      []string
+	}{
+		{
+			name:           "valid JSON array",
+			response:       `[{"category": "made", "text": "Adopt new pipeline", "timestamp": "12:34", "context": "Team voted"}, {"category": "deferred", "text": "Budget review", "timestamp": "13:00", "context": ""}]`,
+			wantCount:      2,
+			wantCategories: []string{"made", "deferred"},
+			wantTexts:      []string{"Adopt new pipeline", "Budget review"},
+		},
+		{
+			name:           "markdown-wrapped response",
+			response:       "```json\n[{\"category\": \"open\", \"text\": \"Discuss architecture\", \"timestamp\": \"09:15\", \"context\": \"Need more info\"}]\n```",
+			wantCount:      1,
+			wantCategories: []string{"open"},
+			wantTexts:      []string{"Discuss architecture"},
+		},
+		{
+			name:      "empty decisions filtered",
+			response:  `[{"category": "made", "text": "", "timestamp": "", "context": ""}, {"category": "made", "text": "Real decision", "timestamp": "10:00", "context": ""}]`,
+			wantCount: 1,
+			wantTexts: []string{"Real decision"},
+		},
+		{
+			name:           "invalid category defaults to open",
+			response:       `[{"category": "bogus", "text": "Some item", "timestamp": "", "context": ""}]`,
+			wantCount:      1,
+			wantCategories: []string{"open"},
+		},
+		{
+			name:      "empty text filtered",
+			response:  `[{"category": "made", "text": "  ", "timestamp": "", "context": ""}]`,
+			wantCount: 0,
+		},
+		{
+			name:      "empty array",
+			response:  `[]`,
+			wantCount: 0,
+		},
+		{
+			name:      "invalid JSON",
+			response:  "not json at all",
+			wantError: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result, err := parseDecisionsResponse(tt.response)
+
+			if tt.wantError {
+				if err == nil {
+					t.Error("expected error, got nil")
+				}
+				return
+			}
+
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+
+			if len(result) != tt.wantCount {
+				t.Errorf("got %d decisions, want %d", len(result), tt.wantCount)
+			}
+
+			for i, wantCat := range tt.wantCategories {
+				if i >= len(result) {
+					break
+				}
+				if result[i].Category != wantCat {
+					t.Errorf("decision[%d]: got category %q, want %q", i, result[i].Category, wantCat)
+				}
+			}
+
+			for i, wantText := range tt.wantTexts {
+				if i >= len(result) {
+					break
+				}
+				if result[i].Text != wantText {
+					t.Errorf("decision[%d]: got text %q, want %q", i, result[i].Text, wantText)
+				}
+			}
+		})
+	}
+}
+
+// Verify the Decision type from models is used correctly
+func TestDecisionModelFields(t *testing.T) {
+	d := models.Decision{
+		Category:  "made",
+		Text:      "Test decision",
+		Timestamp: "12:34",
+		Context:   "Some context",
+	}
+	if d.Category != "made" {
+		t.Errorf("expected category 'made', got %q", d.Category)
+	}
+	if d.Timestamp != "12:34" {
+		t.Errorf("expected timestamp '12:34', got %q", d.Timestamp)
 	}
 }

--- a/internal/organizer/organizer.go
+++ b/internal/organizer/organizer.go
@@ -3,15 +3,24 @@ package organizer
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"strings"
 
 	"github.com/charmbracelet/log"
 	"github.com/jflowers/gcal-organizer/internal/config"
+	"github.com/jflowers/gcal-organizer/internal/docs"
 	"github.com/jflowers/gcal-organizer/internal/drive"
 	"github.com/jflowers/gcal-organizer/internal/logging"
 	"github.com/jflowers/gcal-organizer/pkg/models"
 )
+
+// DocsService defines the Docs operations used for decision extraction.
+type DocsService interface {
+	ExtractTranscriptContent(ctx context.Context, docID string) (*models.TranscriptContent, error)
+	HasDecisionsTab(ctx context.Context, docID string) (bool, error)
+	CreateDecisionsTab(ctx context.Context, docID string, decisions []models.Decision, transcript *models.TranscriptContent) error
+}
 
 // DriveService defines the Drive operations used by the Organizer.
 type DriveService interface {
@@ -34,19 +43,27 @@ type CalendarService interface {
 	ListRecentEvents(ctx context.Context, daysBack int) ([]*models.CalendarEvent, error)
 }
 
+// GeminiService defines the Gemini operations used for decision extraction.
+type GeminiService interface {
+	ExtractDecisions(ctx context.Context, transcriptText string) ([]models.Decision, error)
+}
+
 // Stats tracks operation counts for summary reporting.
 type Stats struct {
-	DocumentsFound    int
-	DocumentsMoved    int
-	ShortcutsCreated  int
-	ShortcutsTrashed  int
-	EventsProcessed   int
-	EventsWithAttach  int
-	AttachmentsShared int
-	TasksAssigned     int
-	TasksFailed       int
-	Skipped           int
-	Errors            int
+	DocumentsFound     int
+	DocumentsMoved     int
+	ShortcutsCreated   int
+	ShortcutsTrashed   int
+	EventsProcessed    int
+	EventsWithAttach   int
+	AttachmentsShared  int
+	TasksAssigned      int
+	TasksFailed        int
+	DecisionsProcessed int
+	DecisionsSkipped   int
+	DecisionsFailed    int
+	Skipped            int
+	Errors             int
 }
 
 // Organizer orchestrates all the services.
@@ -56,18 +73,20 @@ type Organizer struct {
 	calendar CalendarService
 	logger   *log.Logger
 
-	stats       Stats
-	notesDocIDs map[string]bool // Google Doc IDs with "Notes" attachments
+	stats          Stats
+	notesDocIDs    map[string]bool   // Google Doc IDs with "Notes" attachments
+	decisionDocIDs map[string]string // Google Doc IDs for decision extraction (docID→source)
 }
 
 // New creates a new Organizer with all services initialized.
 func New(cfg *config.Config, driveSvc DriveService, calSvc CalendarService) *Organizer {
 	return &Organizer{
-		config:      cfg,
-		drive:       driveSvc,
-		calendar:    calSvc,
-		logger:      logging.Logger,
-		notesDocIDs: make(map[string]bool),
+		config:         cfg,
+		drive:          driveSvc,
+		calendar:       calSvc,
+		logger:         logging.Logger,
+		notesDocIDs:    make(map[string]bool),
+		decisionDocIDs: make(map[string]string),
 	}
 }
 
@@ -78,6 +97,16 @@ func (o *Organizer) GetNotesDocIDs() []string {
 		ids = append(ids, id)
 	}
 	return ids
+}
+
+// GetDecisionDocIDs returns a copy of the map of Google Doc IDs eligible for decision extraction.
+// Keys are doc IDs, values are the source pattern ("notes-by-gemini" or "transcript").
+func (o *Organizer) GetDecisionDocIDs() map[string]string {
+	result := make(map[string]string, len(o.decisionDocIDs))
+	for k, v := range o.decisionDocIDs {
+		result[k] = v
+	}
+	return result
 }
 
 // RunFullWorkflow executes all operations in sequence.
@@ -116,6 +145,84 @@ func (o *Organizer) AddTaskStats(assigned, failed int) {
 	o.stats.TasksFailed += failed
 }
 
+// AddDecisionStats updates the decision extraction statistics.
+func (o *Organizer) AddDecisionStats(processed, skipped, failed int) {
+	o.stats.DecisionsProcessed += processed
+	o.stats.DecisionsSkipped += skipped
+	o.stats.DecisionsFailed += failed
+}
+
+// ExtractDecisionsForDoc orchestrates decision extraction for a single document.
+// It extracts the transcript, calls Gemini for decision extraction, and creates
+// the Decisions tab. Skips on AI failure with a warning (FR-017).
+func (o *Organizer) ExtractDecisionsForDoc(ctx context.Context, docID string, docsSvc DocsService, geminiSvc GeminiService, dryRun bool) error {
+	// Check for existing Decisions tab (idempotency — FR-005)
+	hasTab, err := docsSvc.HasDecisionsTab(ctx, docID)
+	if err != nil {
+		return fmt.Errorf("check decisions tab: %w", err)
+	}
+	if hasTab {
+		o.logger.Info("Document already has Decisions tab, skipping", "docID", docID)
+		o.stats.DecisionsSkipped++
+		return nil
+	}
+
+	// Extract transcript content
+	transcript, err := docsSvc.ExtractTranscriptContent(ctx, docID)
+	if err != nil {
+		return fmt.Errorf("extract transcript: %w", err)
+	}
+	if transcript == nil || transcript.FullText == "" {
+		o.logger.Warn("No transcript content found, skipping", "docID", docID)
+		o.stats.DecisionsSkipped++
+		return nil
+	}
+
+	// Dry-run: log what would happen and return
+	if dryRun {
+		o.logger.Info("Would extract decisions from document",
+			"docID", docID,
+			"transcript_chars", len(transcript.FullText),
+			"headings", len(transcript.Headings),
+		)
+		o.stats.DecisionsProcessed++
+		return nil
+	}
+
+	// Call Gemini for decision extraction
+	decisions, err := geminiSvc.ExtractDecisions(ctx, transcript.FullText)
+	if err != nil {
+		// Skip on AI failure with warning (FR-017)
+		o.logger.Warn("AI decision extraction failed, skipping document",
+			"docID", docID,
+			"error", err,
+		)
+		o.stats.DecisionsFailed++
+		return nil
+	}
+
+	o.logger.Info("Extracted decisions from transcript",
+		"docID", docID,
+		"decisions", len(decisions),
+	)
+
+	// Create the Decisions tab
+	err = docsSvc.CreateDecisionsTab(ctx, docID, decisions, transcript)
+	if err != nil {
+		// Check for sentinel error indicating tab already exists (optimistic concurrency — FR-018)
+		if errors.Is(err, docs.ErrDecisionsTabExists) {
+			o.logger.Info("Decisions tab created by concurrent instance, skipping", "docID", docID)
+			o.stats.DecisionsSkipped++
+			return nil
+		}
+		o.stats.DecisionsFailed++
+		return fmt.Errorf("create decisions tab: %w", err)
+	}
+
+	o.stats.DecisionsProcessed++
+	return nil
+}
+
 // printSummary outputs the final statistics.
 func (o *Organizer) printSummary() {
 	if o.drive.IsDryRun() {
@@ -126,6 +233,9 @@ func (o *Organizer) printSummary() {
 			"events_processed", o.stats.EventsProcessed,
 			"tasks_assigned", o.stats.TasksAssigned,
 		)
+		if o.stats.DecisionsProcessed > 0 {
+			o.logger.Info("Would extract decisions", "documents", o.stats.DecisionsProcessed)
+		}
 		if o.stats.Skipped > 0 {
 			o.logger.Info("Would skip non-owned files (--owned-only active)", "count", o.stats.Skipped)
 		}
@@ -139,6 +249,13 @@ func (o *Organizer) printSummary() {
 			"events_with_attachments", o.stats.EventsWithAttach,
 			"tasks_assigned", o.stats.TasksAssigned,
 		)
+		if o.stats.DecisionsProcessed > 0 || o.stats.DecisionsSkipped > 0 || o.stats.DecisionsFailed > 0 {
+			o.logger.Info("Decision extraction",
+				"processed", o.stats.DecisionsProcessed,
+				"skipped", o.stats.DecisionsSkipped,
+				"failed", o.stats.DecisionsFailed,
+			)
+		}
 		if o.stats.ShortcutsTrashed > 0 {
 			o.logger.Info("Cleanup", "shortcuts_trashed", o.stats.ShortcutsTrashed)
 		}
@@ -256,6 +373,10 @@ func (o *Organizer) SyncCalendarAttachments(ctx context.Context) error {
 			continue
 		}
 
+		// Per-event tracking for decision doc deduplication
+		var eventDecisionDocID string
+		var eventDecisionSource string
+
 		for _, att := range event.Attachments {
 			if att.FileID == "" {
 				continue
@@ -286,6 +407,33 @@ func (o *Organizer) SyncCalendarAttachments(ctx context.Context) error {
 					}
 				}
 				o.notesDocIDs[att.FileID] = true
+			}
+
+			// Track Google Docs eligible for decision extraction (Step 4)
+			// Exact match "Notes by Gemini" or suffix "- Transcript"
+			if att.MimeType == "application/vnd.google-apps.document" {
+				if title == "Notes by Gemini" {
+					// "Notes by Gemini" always wins in per-event deduplication
+					eventDecisionDocID = att.FileID
+					eventDecisionSource = "notes-by-gemini"
+				} else if strings.HasSuffix(title, "- Transcript") && eventDecisionSource != "notes-by-gemini" {
+					// Only use transcript if no "Notes by Gemini" found yet for this event
+					eventDecisionDocID = att.FileID
+					eventDecisionSource = "transcript"
+				}
+			}
+		}
+
+		// Collect the decision doc for this event (if any), applying --owned-only filter
+		if eventDecisionDocID != "" {
+			if o.config.OwnedOnly {
+				owned, err := o.drive.IsFileOwned(ctx, eventDecisionDocID)
+				if err != nil || !owned {
+					eventDecisionDocID = ""
+				}
+			}
+			if eventDecisionDocID != "" {
+				o.decisionDocIDs[eventDecisionDocID] = eventDecisionSource
 			}
 		}
 

--- a/internal/organizer/organizer_test.go
+++ b/internal/organizer/organizer_test.go
@@ -2,9 +2,11 @@ package organizer
 
 import (
 	"context"
+	"fmt"
 	"testing"
 
 	"github.com/jflowers/gcal-organizer/internal/config"
+	"github.com/jflowers/gcal-organizer/internal/docs"
 	"github.com/jflowers/gcal-organizer/internal/drive"
 	"github.com/jflowers/gcal-organizer/internal/logging"
 	"github.com/jflowers/gcal-organizer/pkg/models"
@@ -161,11 +163,12 @@ func (m *mockCalendarService) ListRecentEvents(_ context.Context, _ int) ([]*mod
 // newTestOrganizer creates an Organizer with mock services for testing.
 func newTestOrganizer(cfg *config.Config, driveMock *mockDriveService, calMock *mockCalendarService) *Organizer {
 	return &Organizer{
-		config:      cfg,
-		drive:       driveMock,
-		calendar:    calMock,
-		logger:      logging.Logger,
-		notesDocIDs: make(map[string]bool),
+		config:         cfg,
+		drive:          driveMock,
+		calendar:       calMock,
+		logger:         logging.Logger,
+		notesDocIDs:    make(map[string]bool),
+		decisionDocIDs: make(map[string]string),
 	}
 }
 
@@ -488,5 +491,346 @@ func TestSyncCalendarAttachments_OwnedOnlyFalse_PreservesExistingBehavior(t *tes
 	}
 	if len(driveMock.shareFileCalls) > 0 && driveMock.shareFileCalls[0].fileID != "att1" {
 		t.Errorf("expected ShareFile for att1, got %s", driveMock.shareFileCalls[0].fileID)
+	}
+}
+
+// ---------- T004: Decision document collection tests ----------
+
+func TestDecisionDocCollection(t *testing.T) {
+	tests := []struct {
+		name         string
+		events       []*models.CalendarEvent
+		ownedOnly    bool
+		isFileOwned  map[string]bool
+		wantDocIDs   map[string]string
+		wantDocCount int
+	}{
+		{
+			name: "exact match Notes by Gemini",
+			events: []*models.CalendarEvent{
+				{
+					ID:    "event1",
+					Title: "Weekly",
+					Attachments: []models.Attachment{
+						{FileID: "doc1", Title: "Notes by Gemini", MimeType: "application/vnd.google-apps.document"},
+					},
+				},
+			},
+			wantDocIDs:   map[string]string{"doc1": "notes-by-gemini"},
+			wantDocCount: 1,
+		},
+		{
+			name: "suffix match - Transcript",
+			events: []*models.CalendarEvent{
+				{
+					ID:    "event1",
+					Title: "Standup",
+					Attachments: []models.Attachment{
+						{FileID: "doc2", Title: "ComplyTime Standup - 2026/02/25 14:00 WET - Transcript", MimeType: "application/vnd.google-apps.document"},
+					},
+				},
+			},
+			wantDocIDs:   map[string]string{"doc2": "transcript"},
+			wantDocCount: 1,
+		},
+		{
+			name: "non-matching title rejected",
+			events: []*models.CalendarEvent{
+				{
+					ID:    "event1",
+					Title: "Weekly",
+					Attachments: []models.Attachment{
+						{FileID: "doc3", Title: "Meeting Agenda", MimeType: "application/vnd.google-apps.document"},
+					},
+				},
+			},
+			wantDocIDs:   map[string]string{},
+			wantDocCount: 0,
+		},
+		{
+			name: "per-event deduplication prefers Notes by Gemini",
+			events: []*models.CalendarEvent{
+				{
+					ID:    "event1",
+					Title: "Weekly",
+					Attachments: []models.Attachment{
+						{FileID: "doc-nbg", Title: "Notes by Gemini", MimeType: "application/vnd.google-apps.document"},
+						{FileID: "doc-transcript", Title: "Weekly - 2026/02/25 14:00 WET - Transcript", MimeType: "application/vnd.google-apps.document"},
+					},
+				},
+			},
+			wantDocIDs:   map[string]string{"doc-nbg": "notes-by-gemini"},
+			wantDocCount: 1,
+		},
+		{
+			name: "owned-only filters unowned docs",
+			events: []*models.CalendarEvent{
+				{
+					ID:    "event1",
+					Title: "Weekly",
+					Attachments: []models.Attachment{
+						{FileID: "doc-owned", Title: "Notes by Gemini", MimeType: "application/vnd.google-apps.document"},
+						{FileID: "doc-unowned", Title: "Standup - Transcript", MimeType: "application/vnd.google-apps.document"},
+					},
+				},
+			},
+			ownedOnly:    true,
+			isFileOwned:  map[string]bool{"doc-owned": true, "doc-unowned": false},
+			wantDocIDs:   map[string]string{"doc-owned": "notes-by-gemini"},
+			wantDocCount: 1,
+		},
+		{
+			name: "multiple events collect independently",
+			events: []*models.CalendarEvent{
+				{
+					ID:    "event1",
+					Title: "Weekly",
+					Attachments: []models.Attachment{
+						{FileID: "doc1", Title: "Notes by Gemini", MimeType: "application/vnd.google-apps.document"},
+					},
+				},
+				{
+					ID:    "event2",
+					Title: "Standup",
+					Attachments: []models.Attachment{
+						{FileID: "doc2", Title: "Standup - Transcript", MimeType: "application/vnd.google-apps.document"},
+					},
+				},
+			},
+			wantDocIDs:   map[string]string{"doc1": "notes-by-gemini", "doc2": "transcript"},
+			wantDocCount: 2,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			driveMock := &mockDriveService{
+				isFileOwnedResults: tt.isFileOwned,
+				canEditFileResults: map[string]bool{}, // no sharing in this test
+			}
+			calMock := &mockCalendarService{
+				listRecentEventsReturn: tt.events,
+			}
+			cfg := config.DefaultConfig()
+			cfg.OwnedOnly = tt.ownedOnly
+
+			org := newTestOrganizer(cfg, driveMock, calMock)
+			err := org.SyncCalendarAttachments(context.Background())
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+
+			gotDocIDs := org.GetDecisionDocIDs()
+			if len(gotDocIDs) != tt.wantDocCount {
+				t.Errorf("expected %d decision doc IDs, got %d: %v", tt.wantDocCount, len(gotDocIDs), gotDocIDs)
+			}
+
+			for wantID, wantSource := range tt.wantDocIDs {
+				gotSource, ok := gotDocIDs[wantID]
+				if !ok {
+					t.Errorf("expected doc ID %s in decisionDocIDs, but not found", wantID)
+					continue
+				}
+				if gotSource != wantSource {
+					t.Errorf("doc %s: expected source %q, got %q", wantID, wantSource, gotSource)
+				}
+			}
+		})
+	}
+}
+
+// ---------- Mock DocsService and GeminiService for ExtractDecisionsForDoc tests ----------
+
+type mockDocsService struct {
+	hasDecisionsTab         bool
+	hasDecisionsTabErr      error
+	transcriptContent       *models.TranscriptContent
+	transcriptContentErr    error
+	createDecisionsTabErr   error
+	createDecisionsTabCalls int
+}
+
+func (m *mockDocsService) ExtractTranscriptContent(_ context.Context, _ string) (*models.TranscriptContent, error) {
+	return m.transcriptContent, m.transcriptContentErr
+}
+
+func (m *mockDocsService) HasDecisionsTab(_ context.Context, _ string) (bool, error) {
+	return m.hasDecisionsTab, m.hasDecisionsTabErr
+}
+
+func (m *mockDocsService) CreateDecisionsTab(_ context.Context, _ string, _ []models.Decision, _ *models.TranscriptContent) error {
+	m.createDecisionsTabCalls++
+	return m.createDecisionsTabErr
+}
+
+type mockGeminiService struct {
+	decisions    []models.Decision
+	extractErr   error
+	extractCalls int
+}
+
+func (m *mockGeminiService) ExtractDecisions(_ context.Context, _ string) ([]models.Decision, error) {
+	m.extractCalls++
+	return m.decisions, m.extractErr
+}
+
+// ---------- TestExtractDecisionsForDoc ----------
+
+func TestExtractDecisionsForDoc(t *testing.T) {
+	tests := []struct {
+		name               string
+		docsSvc            *mockDocsService
+		geminiSvc          *mockGeminiService
+		dryRun             bool
+		wantErr            bool
+		wantProcessed      int
+		wantSkipped        int
+		wantFailed         int
+		wantCreateTabCalls int
+		wantGeminiCalls    int
+	}{
+		{
+			name: "already has Decisions tab - skip",
+			docsSvc: &mockDocsService{
+				hasDecisionsTab: true,
+			},
+			geminiSvc:          &mockGeminiService{},
+			wantSkipped:        1,
+			wantGeminiCalls:    0,
+			wantCreateTabCalls: 0,
+		},
+		{
+			name: "no transcript content - skip",
+			docsSvc: &mockDocsService{
+				hasDecisionsTab:   false,
+				transcriptContent: nil,
+			},
+			geminiSvc:          &mockGeminiService{},
+			wantSkipped:        1,
+			wantGeminiCalls:    0,
+			wantCreateTabCalls: 0,
+		},
+		{
+			name: "empty transcript text - skip",
+			docsSvc: &mockDocsService{
+				hasDecisionsTab:   false,
+				transcriptContent: &models.TranscriptContent{TabID: "tab1", FullText: ""},
+			},
+			geminiSvc:          &mockGeminiService{},
+			wantSkipped:        1,
+			wantGeminiCalls:    0,
+			wantCreateTabCalls: 0,
+		},
+		{
+			name:   "dry-run - logs only, no Gemini call",
+			dryRun: true,
+			docsSvc: &mockDocsService{
+				hasDecisionsTab: false,
+				transcriptContent: &models.TranscriptContent{
+					TabID:    "tab1",
+					FullText: "Meeting transcript text",
+				},
+			},
+			geminiSvc:          &mockGeminiService{},
+			wantProcessed:      1,
+			wantGeminiCalls:    0,
+			wantCreateTabCalls: 0,
+		},
+		{
+			name: "Gemini failure - skip with warning",
+			docsSvc: &mockDocsService{
+				hasDecisionsTab: false,
+				transcriptContent: &models.TranscriptContent{
+					TabID:    "tab1",
+					FullText: "Meeting transcript text",
+				},
+			},
+			geminiSvc: &mockGeminiService{
+				extractErr: fmt.Errorf("Gemini API error: rate limited"),
+			},
+			wantFailed:         1,
+			wantGeminiCalls:    1,
+			wantCreateTabCalls: 0,
+		},
+		{
+			name: "concurrent tab creation - sentinel error treated as skip",
+			docsSvc: &mockDocsService{
+				hasDecisionsTab: false,
+				transcriptContent: &models.TranscriptContent{
+					TabID:    "tab1",
+					FullText: "Meeting transcript text",
+				},
+				createDecisionsTabErr: docs.ErrDecisionsTabExists,
+			},
+			geminiSvc: &mockGeminiService{
+				decisions: []models.Decision{
+					{Category: "made", Text: "Test decision"},
+				},
+			},
+			wantSkipped:        1,
+			wantGeminiCalls:    1,
+			wantCreateTabCalls: 1,
+		},
+		{
+			name: "happy path - decisions extracted and tab created",
+			docsSvc: &mockDocsService{
+				hasDecisionsTab: false,
+				transcriptContent: &models.TranscriptContent{
+					TabID:    "tab1",
+					FullText: "Meeting transcript with decisions",
+				},
+			},
+			geminiSvc: &mockGeminiService{
+				decisions: []models.Decision{
+					{Category: "made", Text: "Adopt new pipeline", Timestamp: "12:34"},
+					{Category: "deferred", Text: "Budget review", Timestamp: "13:00"},
+				},
+			},
+			wantProcessed:      1,
+			wantGeminiCalls:    1,
+			wantCreateTabCalls: 1,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			driveMock := &mockDriveService{}
+			calMock := &mockCalendarService{}
+			cfg := config.DefaultConfig()
+			org := newTestOrganizer(cfg, driveMock, calMock)
+
+			err := org.ExtractDecisionsForDoc(context.Background(), "test-doc-id", tt.docsSvc, tt.geminiSvc, tt.dryRun)
+
+			if tt.wantErr {
+				if err == nil {
+					t.Error("expected error, got nil")
+				}
+				return
+			}
+
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+
+			if org.stats.DecisionsProcessed != tt.wantProcessed {
+				t.Errorf("DecisionsProcessed: got %d, want %d", org.stats.DecisionsProcessed, tt.wantProcessed)
+			}
+
+			if org.stats.DecisionsSkipped != tt.wantSkipped {
+				t.Errorf("DecisionsSkipped: got %d, want %d", org.stats.DecisionsSkipped, tt.wantSkipped)
+			}
+
+			if org.stats.DecisionsFailed != tt.wantFailed {
+				t.Errorf("DecisionsFailed: got %d, want %d", org.stats.DecisionsFailed, tt.wantFailed)
+			}
+
+			if tt.docsSvc.createDecisionsTabCalls != tt.wantCreateTabCalls {
+				t.Errorf("CreateDecisionsTab calls: got %d, want %d", tt.docsSvc.createDecisionsTabCalls, tt.wantCreateTabCalls)
+			}
+
+			if tt.geminiSvc.extractCalls != tt.wantGeminiCalls {
+				t.Errorf("ExtractDecisions calls: got %d, want %d", tt.geminiSvc.extractCalls, tt.wantGeminiCalls)
+			}
+		})
 	}
 }

--- a/man/gcal-organizer.1
+++ b/man/gcal-organizer.1
@@ -9,7 +9,7 @@ gcal-organizer \- automate meeting note organization, calendar syncing, and task
 .SH DESCRIPTION
 .B gcal-organizer
 is a CLI tool that automates meeting note organization using Google Workspace APIs
-and Gemini AI. It runs a 3-step workflow:
+and Gemini AI. It runs a 4-step workflow:
 .PP
 .B Step 1: Organize
 \- Finds meeting docs matching a naming pattern (e.g.,
@@ -26,10 +26,19 @@ with all event attendees (writer access).
 \- Extracts checkbox items from Google Docs, uses Gemini AI to identify
 assignees, and automates Chrome via Playwright to click the native
 "Assign as a task" widget in Google Docs.
+.PP
+.B Step 4: Extract Decisions
+\- Reads meeting transcript documents (matched by "Notes by Gemini" exact
+title or "- Transcript" suffix), sends the transcript text to Gemini AI
+for decision extraction, and creates a "Decisions" tab in the document
+with three categorized sections: Decisions Made, Decisions Deferred,
+and Open Items. Each decision includes a clickable timestamp link back
+to the corresponding heading in the Transcript tab. Documents with an
+existing Decisions tab are skipped (idempotent).
 .SH COMMANDS
 .TP
 .B run
-Execute the full 3-step workflow.
+Execute the full 4-step workflow.
 .TP
 .B organize
 Step 1 only: organize documents into topic folders.
@@ -93,6 +102,11 @@ commands.
 .TP
 .B \-\-config \fIFILE\fR
 Path to config file (default: ~/.gcal-organizer/config.yaml).
+.TP
+.B \-\-no\-keyring
+Disable OS credential store (macOS Keychain, Linux Secret Service); use
+file-based storage instead. Useful for headless servers or environments
+without a credential store. Can also be set via GCAL_NO_KEYRING=true.
 .SH ENVIRONMENT
 .TP
 .B GEMINI_API_KEY
@@ -114,7 +128,10 @@ Comma-separated keywords to filter documents (default: "Notes,Meeting").
 Regex for parsing document names (default: (.+)\\s*-\\s*(\\d{4}-\\d{2}-\\d{2})).
 .TP
 .B GEMINI_MODEL
-Gemini model to use (default: gemini-1.5-flash).
+Gemini model to use (default: gemini-2.0-flash).
+.TP
+.B GCAL_NO_KEYRING
+When set to "true", disable OS credential store; use file-based storage (default: false).
 .TP
 .B GCAL_ORGANIZER_BIN
 Override path to the gcal-organizer binary (used by the service wrapper).
@@ -124,7 +141,9 @@ Override path to the gcal-organizer binary (used by the service wrapper).
 Google OAuth2 client credentials.
 .TP
 .I ~/.gcal-organizer/token.json
-Stored OAuth2 token (auto-generated on first login).
+Stored OAuth2 token. Used only in file-based fallback mode (\-\-no\-keyring
+or when the OS keychain is unavailable). When the keychain is active,
+tokens are stored in the OS credential store instead.
 .TP
 .I ~/.gcal-organizer/config.yaml
 Configuration file (optional, env vars take precedence).
@@ -171,9 +190,9 @@ and
 .B setup-browser
 commands will detect Flatpak Chrome and warn if this override is missing.
 .SH DATA PRIVACY
-Only the text of individual checkbox items is sent to Gemini AI for assignee
-extraction. Full document contents are never uploaded. OAuth tokens and
-credentials are stored locally and never transmitted.
+Individual checkbox items are sent to Gemini AI for assignee extraction (Step 3).
+Full transcript text is sent to Gemini for decision extraction (Step 4).
+OAuth tokens and credentials are stored locally and never transmitted.
 .SH EXAMPLES
 .TP
 Run the full workflow with verbose output:

--- a/pkg/models/models.go
+++ b/pkg/models/models.go
@@ -91,6 +91,45 @@ type Attachment struct {
 	FileURL string
 }
 
+// Decision represents a single decision extracted from a meeting transcript.
+type Decision struct {
+	// Category is the decision classification: "made", "deferred", or "open"
+	Category string
+
+	// Text is the description of the decision
+	Text string
+
+	// Timestamp is the associated meeting timestamp (HH:MM format, or empty)
+	Timestamp string
+
+	// Context is a brief excerpt from the transcript providing context
+	Context string
+}
+
+// TranscriptHeading represents an H3 timestamp heading in a Transcript tab.
+type TranscriptHeading struct {
+	// HeadingID is the server-assigned heading identifier (e.g., "h.xxxxxxxx")
+	HeadingID string
+
+	// Text is the display text of the heading (e.g., "12:34")
+	Text string
+
+	// Index is the zero-based position in the document body
+	Index int64
+}
+
+// TranscriptContent aggregates the full parsed content of a transcript tab.
+type TranscriptContent struct {
+	// TabID is the Transcript tab identifier
+	TabID string
+
+	// FullText is the complete text content of the transcript
+	FullText string
+
+	// Headings is the ordered list of H3 timestamp headings
+	Headings []TranscriptHeading
+}
+
 // Attendee represents a calendar event attendee.
 type Attendee struct {
 	// Email is the attendee's email address

--- a/specs/006-owned-only-flag/spec.md
+++ b/specs/006-owned-only-flag/spec.md
@@ -2,7 +2,7 @@
 
 **Feature Branch**: `006-owned-only-flag`  
 **Created**: 2026-02-26  
-**Status**: Draft  
+**Status**: Implemented  
 **Input**: User description: "Add --owned-only global flag to prevent mutations on files not owned by the authenticated user, allowing only read-only operations like shortcut creation on non-owned files"
 
 ## User Scenarios & Testing *(mandatory)*

--- a/specs/007-secure-credential-storage/spec.md
+++ b/specs/007-secure-credential-storage/spec.md
@@ -2,7 +2,7 @@
 
 **Feature Branch**: `007-secure-credential-storage`  
 **Created**: 2026-02-26  
-**Status**: Draft  
+**Status**: In Progress (Phases 1-5,7 complete; Phase 6 migration, Phase 8 polish pending)  
 **Input**: User concern about auth/token information stored in cleartext
 
 ---

--- a/specs/007-secure-credential-storage/tasks.md
+++ b/specs/007-secure-credential-storage/tasks.md
@@ -61,11 +61,11 @@
 
 ### Implementation
 
-- [ ] T013 [US1] Refactor `OAuthClient` in `internal/auth/oauth.go`: replace `tokenFile string` field with `store secrets.SecretStore` field. Add `credsFallbackPath string` field. Update `NewOAuthClient` signature to `NewOAuthClient(store secrets.SecretStore, credsFallbackPath string) (*OAuthClient, error)` — load client credentials from `store.Get(KeyClientCredentials)` first, fall back to reading `credsFallbackPath` file. Parse credentials via `google.ConfigFromJSON(bytes, Scopes...)`. If neither source has credentials, return an actionable error referencing `auth login` and `doctor` (Constitution Principle VII). Also remove `ValidateForWorkflow()` from `internal/config/config.go` (dead code — zero callers; its `os.Stat` check would fail after keychain migration).
-- [ ] T014 [US1] Rewrite `loadToken()` in `internal/auth/oauth.go` to call `o.store.Get(secrets.KeyOAuthToken)` and JSON-unmarshal the result. Rewrite `saveToken()` to JSON-marshal and call `o.store.Set(secrets.KeyOAuthToken, ...)`.
-- [ ] T015 [US1] Implement `persistingTokenSource` struct in `internal/auth/oauth.go` — fields: `base oauth2.TokenSource`, `store secrets.SecretStore`, `current *oauth2.Token`, `mu sync.Mutex`. `Token()` method: call `base.Token()`, compare `AccessToken` and `Expiry` with `current`, if different call `saveToken` equivalent via `store.Set`, update `current`, return token. Per research.md R3.
-- [ ] T016 [US1] Update `GetClient()` in `internal/auth/oauth.go` to wrap the `oauth2.Config.TokenSource(ctx, tok)` with `persistingTokenSource` before creating `oauth2.NewClient(ctx, persistingTS)`.
-- [ ] T017 [US1] Update all callers of `NewOAuthClient` in `cmd/gcal-organizer/` — pass the `SecretStore` instance and `cfg.CredentialsFile` as fallback path. Update `auth_config.go` (`auth login`, `auth status`) and any command `RunE` functions that create an `OAuthClient`.
+- [x] T013 [US1] Refactor `OAuthClient` in `internal/auth/oauth.go`: replace `tokenFile string` field with `store secrets.SecretStore` field. Add `credsFallbackPath string` field. Update `NewOAuthClient` signature to `NewOAuthClient(store secrets.SecretStore, credsFallbackPath string) (*OAuthClient, error)` — load client credentials from `store.Get(KeyClientCredentials)` first, fall back to reading `credsFallbackPath` file. Parse credentials via `google.ConfigFromJSON(bytes, Scopes...)`. If neither source has credentials, return an actionable error referencing `auth login` and `doctor` (Constitution Principle VII). Also remove `ValidateForWorkflow()` from `internal/config/config.go` (dead code — zero callers; its `os.Stat` check would fail after keychain migration).
+- [x] T014 [US1] Rewrite `loadToken()` in `internal/auth/oauth.go` to call `o.store.Get(secrets.KeyOAuthToken)` and JSON-unmarshal the result. Rewrite `saveToken()` to JSON-marshal and call `o.store.Set(secrets.KeyOAuthToken, ...)`.
+- [x] T015 [US1] Implement `persistingTokenSource` struct in `internal/auth/oauth.go` — fields: `base oauth2.TokenSource`, `store secrets.SecretStore`, `current *oauth2.Token`, `mu sync.Mutex`. `Token()` method: call `base.Token()`, compare `AccessToken` and `Expiry` with `current`, if different call `saveToken` equivalent via `store.Set`, update `current`, return token. Per research.md R3.
+- [x] T016 [US1] Update `GetClient()` in `internal/auth/oauth.go` to wrap the `oauth2.Config.TokenSource(ctx, tok)` with `persistingTokenSource` before creating `oauth2.NewClient(ctx, persistingTS)`.
+- [x] T017 [US1] Update all callers of `NewOAuthClient` in `cmd/gcal-organizer/` — pass the `SecretStore` instance and `cfg.CredentialsFile` as fallback path. Update `auth_config.go` (`auth login`, `auth status`) and any command `RunE` functions that create an `OAuthClient`.
 - [ ] T018 [US1] Run `go test ./internal/auth/... ./internal/secrets/...` and verify T010-T012 pass. Run `go build ./...` to verify no compilation errors across the project.
 
 **Checkpoint**: OAuth tokens are stored in and loaded from the SecretStore. Token refresh is persisted. `auth login` and `auth status` work with the new backend.
@@ -85,9 +85,9 @@
 
 ### Implementation
 
-- [ ] T021 [US2] Add `LoadSecrets(store secrets.SecretStore) error` method to `*Config` in `internal/config/config.go`. Check `store.Get(secrets.KeyGeminiAPIKey)` — if found, override `c.GeminiAPIKey` with the keychain value. If `ErrNotFound`, keep the existing value from `Load()` (env var / viper). `Load()` signature remains unchanged.
+- [x] T021 [US2] Add `LoadSecrets(store secrets.SecretStore) error` method to `*Config` in `internal/config/config.go`. Check `store.Get(secrets.KeyGeminiAPIKey)` — if found, override `c.GeminiAPIKey` with the keychain value. If `ErrNotFound`, keep the existing value from `Load()` (env var / viper). `Load()` signature remains unchanged.
 - [ ] T022 [US2] Update `init` command in `cmd/gcal-organizer/selfservice.go` to store the user-provided API key in the `SecretStore` via `store.Set(KeyGeminiAPIKey, apiKey)` when keychain is available, instead of (or in addition to) writing it to `.env`.
-- [ ] T023 [US2] Update all callers of `config.Load()` in `cmd/gcal-organizer/` to add `cfg.LoadSecrets(store)` after `config.Load()` and `secrets.NewStore()`. The `Load()` call itself is unchanged. Startup flow: `cfg, _ := config.Load()` → `store, backend := secrets.NewStore(cfg.NoKeyring)` → `cfg.LoadSecrets(store)`. Ensure `config show` still displays the masked API key correctly regardless of source.
+- [x] T023 [US2] Update all callers of `config.Load()` in `cmd/gcal-organizer/` to add `cfg.LoadSecrets(store)` after `config.Load()` and `secrets.NewStore()`. The `Load()` call itself is unchanged. Startup flow: `cfg, _ := config.Load()` → `store, backend := secrets.NewStore(cfg.NoKeyring)` → `cfg.LoadSecrets(store)`. Ensure `config show` still displays the masked API key correctly regardless of source.
 - [ ] T024 [US2] Run `go test ./internal/config/... ./internal/secrets/...` and verify T019-T020 pass. Run `go build ./...`.
 
 **Checkpoint**: API key is loaded from keychain first, env var second. `init` stores keys in keychain. Config commands work correctly.
@@ -103,8 +103,8 @@
 ### Implementation
 
 - [ ] T025 [US3] Verify `NewOAuthClient` in `internal/auth/oauth.go` (already implemented in T013) correctly reads `KeyClientCredentials` from store first, falls back to file. Add a test `TestOAuthClient_LoadCredentialsFromStore` in `internal/auth/oauth_test.go` — pre-populate `KeyClientCredentials` in mock store with a valid `credentials.json` blob, verify `NewOAuthClient` succeeds without any file on disk.
-- [ ] T026 [US3] Update `auth login` in `cmd/gcal-organizer/auth_config.go` — after successfully reading `credentials.json` for the login flow, call `store.Set(KeyClientCredentials, fileContents)` to persist the blob in the credential store.
-- [ ] T027 [US3] Update `auth status` in `cmd/gcal-organizer/auth_config.go` — check for client credentials in store first (`store.Get(KeyClientCredentials)`), then file. Report presence/absence accordingly.
+- [x] T026 [US3] Update `auth login` in `cmd/gcal-organizer/auth_config.go` — after successfully reading `credentials.json` for the login flow, call `store.Set(KeyClientCredentials, fileContents)` to persist the blob in the credential store.
+- [x] T027 [US3] Update `auth status` in `cmd/gcal-organizer/auth_config.go` — check for client credentials in store first (`store.Get(KeyClientCredentials)`), then file. Report presence/absence accordingly.
 - [ ] T028 [US3] Run `go test ./internal/auth/...` and verify T025 passes. Run `go build ./...`.
 
 **Checkpoint**: Client credentials are stored in keychain during login. Auth commands work with credentials from either store or file.
@@ -147,8 +147,8 @@
 
 ### Implementation
 
-- [ ] T038 [US5] Add `NoKeyring bool` field to `Config` struct in `internal/config/config.go`. Add viper binding: `viper.BindEnv("no_keyring", "GCAL_NO_KEYRING")`. Load via `cfg.NoKeyring = viper.GetBool("no-keyring")`.
-- [ ] T039 [US5] Add `--no-keyring` persistent flag on `rootCmd` in `cmd/gcal-organizer/main.go` — `rootCmd.PersistentFlags().Bool("no-keyring", false, "Disable OS credential store; use file-based storage")`. Bind to viper: `viper.BindPFlag("no-keyring", rootCmd.PersistentFlags().Lookup("no-keyring"))`.
+- [x] T038 [US5] Add `NoKeyring bool` field to `Config` struct in `internal/config/config.go`. Add viper binding: `viper.BindEnv("no_keyring", "GCAL_NO_KEYRING")`. Load via `cfg.NoKeyring = viper.GetBool("no-keyring")`.
+- [x] T039 [US5] Add `--no-keyring` persistent flag on `rootCmd` in `cmd/gcal-organizer/main.go` — `rootCmd.PersistentFlags().Bool("no-keyring", false, "Disable OS credential store; use file-based storage")`. Bind to viper: `viper.BindPFlag("no-keyring", rootCmd.PersistentFlags().Lookup("no-keyring"))`.
 - [ ] T040 [US5] Run `go test ./internal/config/... ./internal/secrets/...` and verify T036-T037 pass. Run `go build ./...`.
 
 **Checkpoint**: `--no-keyring` and `GCAL_NO_KEYRING` force file-based storage. Unavailable keyring falls back gracefully.
@@ -160,8 +160,8 @@
 **Purpose**: Doctor reporting, documentation, and final validation.
 
 - [ ] T041 [P] Update `doctor` command in `cmd/gcal-organizer/selfservice.go` — add a new check reporting secret storage backend: "Secrets stored in OS keychain" (pass) or "Secrets stored in plaintext files" (warn with fix suggestion). When `--verbose`, report per-secret status (`oauth-token: present/absent`, `gemini-api-key: present/absent`, `credentials-json: present/absent`). Update the `token.json` check to handle keychain-based storage (token may not be a file anymore).
-- [ ] T042 [P] Update `config show` in `cmd/gcal-organizer/auth_config.go` — replace "Token File: ..." line with "Secret storage: OS keychain" or "Secret storage: plaintext files" depending on active backend. Keep masked API key display.
-- [ ] T043 [P] Update `auth status` in `cmd/gcal-organizer/auth_config.go` — report storage backend alongside authentication status.
+- [x] T042 [P] Update `config show` in `cmd/gcal-organizer/auth_config.go` — replace "Token File: ..." line with "Secret storage: OS keychain" or "Secret storage: plaintext files" depending on active backend. Keep masked API key display.
+- [x] T043 [P] Update `auth status` in `cmd/gcal-organizer/auth_config.go` — report storage backend alongside authentication status.
 - [ ] T044 [P] Update `README.md` — add "Secure Credential Storage" section documenting keychain behavior, `--no-keyring` flag, `GCAL_NO_KEYRING` env var, migration behavior, and behavior comparison table (from quickstart.md).
 - [ ] T045 [P] Update `docs/SETUP.md` — update credential setup instructions to mention keychain storage as default, add guidance for headless environments and `--no-keyring` opt-out.
 - [ ] T046 [P] Update `man/gcal-organizer.1` — add `--no-keyring` flag description, update credential storage documentation.

--- a/specs/008-decision-extraction/checklists/requirements.md
+++ b/specs/008-decision-extraction/checklists/requirements.md
@@ -1,0 +1,37 @@
+# Specification Quality Checklist: Decision Extraction from Meeting Transcripts
+
+**Purpose**: Validate specification completeness and quality before proceeding to planning  
+**Created**: 2026-02-26  
+**Feature**: [spec.md](../spec.md)
+
+## Content Quality
+
+- [x] No implementation details (languages, frameworks, APIs)
+- [x] Focused on user value and business needs
+- [x] Written for non-technical stakeholders
+- [x] All mandatory sections completed
+
+## Requirement Completeness
+
+- [x] No [NEEDS CLARIFICATION] markers remain
+- [x] Requirements are testable and unambiguous
+- [x] Success criteria are measurable
+- [x] Success criteria are technology-agnostic (no implementation details)
+- [x] All acceptance scenarios are defined
+- [x] Edge cases are identified
+- [x] Scope is clearly bounded
+- [x] Dependencies and assumptions identified
+
+## Feature Readiness
+
+- [x] All functional requirements have clear acceptance criteria
+- [x] User scenarios cover primary flows
+- [x] Feature meets measurable outcomes defined in Success Criteria
+- [x] No implementation details leak into specification
+
+## Notes
+
+- All items pass validation. Spec is ready for `/speckit.clarify` or `/speckit.plan`.
+- The spec references "AI" generically rather than naming specific models or APIs, keeping it technology-agnostic.
+- Success criteria SC-002 (90% accuracy) is verifiable via manual review of sample transcripts post-implementation.
+- Assumptions are documented in the spec regarding transcript document structure (H3 timestamp headings) and existing authorization scope.

--- a/specs/008-decision-extraction/data-model.md
+++ b/specs/008-decision-extraction/data-model.md
@@ -1,0 +1,125 @@
+# Data Model: Decision Extraction from Meeting Transcripts
+
+**Feature**: `008-decision-extraction` | **Date**: 2026-02-26
+
+## Entities
+
+### Decision
+
+Represents a single decision extracted from a meeting transcript by the AI.
+
+| Field | Type | Description | Constraints |
+|-------|------|-------------|-------------|
+| Category | string | Decision classification | One of: `"made"`, `"deferred"`, `"open"` |
+| Text | string | Description of the decision | Non-empty |
+| Timestamp | string | Associated meeting timestamp | Format: `"HH:MM"` or empty if not identifiable |
+| Context | string | Brief excerpt from the transcript providing context | May be empty |
+
+**Validation rules**:
+- `Category` must be one of the three allowed values
+- `Text` must not be empty
+- `Timestamp` is optional; when present, must match a heading in the transcript
+
+**Notes**: Decisions are transient — they exist only during the processing pipeline between Gemini response parsing and Docs API content insertion. They are not persisted to disk or database.
+
+### TranscriptHeading
+
+Represents an H3 timestamp heading found in the Transcript tab of a document.
+
+| Field | Type | Description | Constraints |
+|-------|------|-------------|-------------|
+| HeadingID | string | Server-assigned heading identifier | Read-only from Docs API, format: `"h.xxxxxxxx"` |
+| Text | string | Display text of the heading | Typically a timestamp like `"12:34"` |
+| Index | int64 | Zero-based position in the document body | >= 0 |
+
+**Validation rules**:
+- `HeadingID` must be non-empty (only populated for actual headings)
+- `Text` extracted from `ParagraphStyle.HeadingId` parent paragraph content
+
+**Notes**: HeadingIDs are assigned by the Google Docs server and are immutable. They are used to construct cross-tab `HeadingLink` references.
+
+### TranscriptContent
+
+Aggregates the full parsed content of a transcript tab.
+
+| Field | Type | Description | Constraints |
+|-------|------|-------------|-------------|
+| TabID | string | The Transcript tab identifier | Non-empty |
+| FullText | string | Complete text content of the transcript | May be empty for edge case |
+| Headings | []TranscriptHeading | Ordered list of H3 timestamp headings | May be empty if no headings found |
+
+**Relationships**:
+- Contains zero or more `TranscriptHeading` entries
+- Referenced by `Decision` via `Timestamp` → nearest `TranscriptHeading.Text` match
+
+### DecisionDocCandidate
+
+Represents a document collected during calendar sync for decision processing in Step 4. Internal to the organizer — not a persisted entity.
+
+| Field | Type | Description | Constraints |
+|-------|------|-------------|-------------|
+| DocID | string | Google Drive file ID | Non-empty |
+| Source | string | Which pattern matched | `"notes-by-gemini"` or `"transcript"` |
+
+**Validation rules**:
+- Per-event deduplication: if both sources match on the same event, only `"notes-by-gemini"` is kept
+
+## Entity Relationships
+
+```text
+CalendarEvent (existing)
+  └── Attachment (existing)
+        └── DecisionDocCandidate (new, transient)
+              └── TranscriptContent (new, transient)
+                    ├── TranscriptHeading[] (new, transient)
+                    └── Decision[] (new, transient, from Gemini)
+```
+
+## State Transitions
+
+Documents move through a simple linear state:
+
+```text
+[Unprocessed] → [Processing] → [Decisions Tab Created]
+                     │
+                     └─→ [Skipped] (on error or AI failure)
+```
+
+- **Unprocessed → Processing**: Document passes title match + no existing Decisions tab
+- **Processing → Decisions Tab Created**: All 3 API calls succeed; tab with content exists
+- **Processing → Skipped**: AI failure (FR-017), API error, or concurrent creation (FR-018)
+- **Decisions Tab Created → (terminal)**: Idempotent; subsequent runs skip via FR-005
+
+There is no reverse transition. Once a Decisions tab exists, it is permanent. Users can manually delete the tab to trigger reprocessing on the next run.
+
+## Gemini Response Schema
+
+The AI returns a JSON array conforming to this schema:
+
+```json
+[
+  {
+    "category": "made | deferred | open",
+    "text": "Description of the decision",
+    "timestamp": "HH:MM",
+    "context": "Brief transcript excerpt"
+  }
+]
+```
+
+**Parsing rules**:
+- Strip markdown code fences (```` ```json ````) if present
+- Extract JSON array from response text using regex `\[[\s\S]*\]`
+- Parse into `[]Decision` structs
+- Filter out entries with empty `Text` field
+- Validate `Category` is one of the three allowed values; default to `"open"` if invalid
+
+## Timestamp-to-Heading Matching
+
+When associating a `Decision.Timestamp` with a `TranscriptHeading`:
+
+1. Parse the decision's timestamp as `HH:MM`
+2. Find the `TranscriptHeading` whose `Text` contains the matching timestamp
+3. If exact match found → use that heading's `HeadingID` for linking
+4. If no exact match → find the nearest preceding heading by document position
+5. If no headings at all → decision is rendered without a clickable link (text-only timestamp)

--- a/specs/008-decision-extraction/plan.md
+++ b/specs/008-decision-extraction/plan.md
@@ -1,0 +1,109 @@
+# Implementation Plan: Decision Extraction from Meeting Transcripts
+
+**Branch**: `008-decision-extraction` | **Date**: 2026-02-26 | **Spec**: [spec.md](spec.md)
+**Input**: Feature specification from `/specs/008-decision-extraction/spec.md`
+
+## Summary
+
+Extract decisions (made, deferred, open) from meeting transcript documents attached to calendar events and write them into a new "Decisions" tab in the same document with cross-tab links to transcript timestamp headings. Integrates into the existing `run` workflow as Step 4, using the Google Docs BatchUpdate API for tab creation/content insertion and the Gemini API for transcript analysis.
+
+## Technical Context
+
+**Language/Version**: Go 1.24+ (module `github.com/jflowers/gcal-organizer`)
+**Primary Dependencies**: `google.golang.org/api/docs/v1` (Docs API — tab creation, content insertion, heading links), `google.golang.org/genai` (Gemini SDK — transcript analysis), `github.com/spf13/cobra` (CLI), `github.com/spf13/viper` (config)
+**Storage**: N/A (no new data persistence; decisions written directly to Google Docs)
+**Testing**: `go test` with table-driven tests; mock-based integration tests for Docs API interactions
+**Target Platform**: macOS (primary), Linux (secondary) — CLI tool
+**Project Type**: Single project — extends existing `cmd/`, `internal/`, `pkg/` structure
+**Performance Goals**: <30 seconds per document (SC-001); dominated by Gemini API latency (~5-15s for transcript analysis)
+**Constraints**: 3 Google API calls per document (1 GET + 2 BatchUpdate); Gemini 2.0 Flash 1M token context window for full transcripts
+**Scale/Scope**: Typically 1-10 documents per hourly run; transcript length 5-120 minutes
+
+## Constitution Check
+
+*GATE: Must pass before Phase 0 research. Re-check after Phase 1 design.*
+
+| Principle | Status | Notes |
+|-----------|--------|-------|
+| I. CLI-First Architecture | PASS | Integrates into existing `run` command; no new commands required |
+| II. API-Key Authentication | PASS | Reuses existing OAuth2 for Docs API + GCP API key for Gemini |
+| III. Test-Driven Development | PASS | Tests before implementation; table-driven tests for Gemini response parsing, mock-based tests for Docs API |
+| IV. Idiomatic Go | PASS | Standard project layout; new code in `internal/docs/`, `internal/gemini/`, `internal/organizer/` |
+| V. Graceful Error Handling | PASS | FR-017 (skip on AI failure), FR-018 (optimistic concurrency), error wrapping with `%w` |
+| VI. Observability | PASS | Structured logging for each document processed; dry-run mode support (FR-013) |
+| VII. Self-Serve Diagnostics | PASS | Errors include `Run 'gcal-organizer doctor'` guidance per constitution |
+| Quality Gates | PASS | `go build`, `go test`, `go vet`, `gofmt`, `go mod tidy` |
+| Documentation | PASS | README.md + man page updates required before completion |
+| YAGNI | PASS | No new CLI commands, no new config options, no new dependencies |
+
+**Pre-design gate: PASS** — No violations. No complexity tracking needed.
+
+## Project Structure
+
+### Documentation (this feature)
+
+```text
+specs/008-decision-extraction/
+├── plan.md              # This file
+├── research.md          # Phase 0 output
+├── data-model.md        # Phase 1 output
+├── quickstart.md        # Phase 1 output
+└── tasks.md             # Phase 2 output (/speckit.tasks)
+```
+
+### Source Code (repository root)
+
+```text
+gcal-organizer/
+├── cmd/gcal-organizer/
+│   └── main.go                    # Wire Step 4 into run command
+├── internal/
+│   ├── docs/
+│   │   └── service.go             # New methods: ExtractTranscriptContent, HasDecisionsTab, CreateDecisionsTab
+│   ├── gemini/
+│   │   ├── client.go              # New method: ExtractDecisions
+│   │   └── client_test.go         # New tests: TestExtractDecisionsResponse
+│   └── organizer/
+│       ├── organizer.go           # New: decisionDocIDs collection, GetDecisionDocIDs(), DocsService interface
+│       └── organizer_test.go      # New tests for decision doc collection
+└── pkg/models/
+    └── models.go                  # New: Decision, TranscriptHeading structs
+```
+
+**Structure Decision**: Extends existing packages only. No new packages created. The `internal/docs/` service gains write capability (previously read-only). The organizer gains a new `DocsService` interface for the decision extraction flow.
+
+## API Call Pattern
+
+Each document requires 3 Google API calls:
+
+1. **GET `Documents.Get(docID)`** — Read full document with all tabs
+   - Find Transcript tab → extract text + H3 heading IDs
+   - Check for existing Decisions tab → skip if present (FR-005)
+
+2. **BatchUpdate #1: `AddDocumentTab`** — Create "Decisions" tab
+   - Response returns server-assigned `TabId`
+   - If API rejects (duplicate tab), treat as already processed (FR-018)
+
+3. **BatchUpdate #2: Content insertion** — Target new tab via `TabId`
+   - `InsertText` — section headings + decision bullet text
+   - `UpdateParagraphStyle` — style H2 headings
+   - `CreateParagraphBullets` — bullet each decision
+   - `UpdateTextStyle` — apply cross-tab `HeadingLink` to timestamp text
+
+Plus 1 Gemini API call between steps 1 and 2:
+- `GenerateContent` — full transcript text → structured JSON decisions
+
+## Post-Design Constitution Re-Check
+
+| Principle | Status | Notes |
+|-----------|--------|-------|
+| I. CLI-First Architecture | PASS | No new commands; Step 4 integrated into `run` |
+| II. API-Key Authentication | PASS | No new auth flows |
+| III. Test-Driven Development | PASS | Tests planned for all new functions |
+| IV. Idiomatic Go | PASS | No new dependencies; extends existing interfaces |
+| V. Graceful Error Handling | PASS | Skip-on-failure + optimistic concurrency |
+| VI. Observability | PASS | Per-document logging + dry-run support |
+| VII. Self-Serve Diagnostics | PASS | Error messages include doctor reference |
+| Documentation | PASS | README, AGENTS.md updates tracked |
+
+**Post-design gate: PASS**

--- a/specs/008-decision-extraction/quickstart.md
+++ b/specs/008-decision-extraction/quickstart.md
@@ -1,0 +1,97 @@
+# Quickstart: Decision Extraction from Meeting Transcripts
+
+**Feature**: `008-decision-extraction` | **Date**: 2026-02-26
+
+## Prerequisites
+
+- Go 1.24+ installed
+- Existing `gcal-organizer` setup complete (`gcal-organizer doctor` passes)
+- OAuth2 credentials with `documents` scope (already authorized)
+- `GEMINI_API_KEY` configured
+- At least one calendar event with a "Notes by Gemini" or "- Transcript" attachment
+
+## How It Works
+
+Decision extraction runs as Step 4 of the `gcal-organizer run` workflow:
+
+```
+Step 1: Organize Documents (existing)
+Step 2: Sync Calendar Attachments (existing) ← collects transcript doc IDs
+Step 3: Assign Tasks (existing)
+Step 4: Extract Decisions (new) ← processes collected transcript docs
+```
+
+## Usage
+
+The feature integrates into the existing `run` command with no new flags or commands:
+
+```bash
+# Full workflow including decision extraction
+gcal-organizer run
+
+# Preview mode — see which docs would be processed
+gcal-organizer run --dry-run
+
+# Only process documents you own
+gcal-organizer run --owned-only
+
+# Process events from the last 7 days
+gcal-organizer run --days 7
+```
+
+## What Gets Created
+
+For each eligible document, a new "Decisions" tab is added with:
+
+1. **Decisions Made** — decisions the team committed to
+2. **Decisions Deferred** — items explicitly tabled for later
+3. **Open Items** — unresolved topics still under discussion
+
+Each decision is a bullet point with a clickable timestamp link back to the transcript.
+
+## Document Detection
+
+The system looks for two types of calendar event attachments:
+
+| Pattern | Match Type | Example |
+|---------|-----------|---------|
+| `Notes by Gemini` | Exact title match | "Notes by Gemini" |
+| `- Transcript` | Title suffix match | "ComplyTime Standup - 2026/02/25 14:00 WET - Transcript" |
+
+If both types are attached to the same event, only the "Notes by Gemini" document is processed.
+
+## Idempotency
+
+Documents that already have a "Decisions" tab are skipped automatically. The workflow is safe to run repeatedly — it will never create duplicate tabs.
+
+## Error Handling
+
+- **AI failure**: Document is skipped with a warning. The next run will retry automatically (no Decisions tab was created).
+- **Concurrent processing**: If another instance creates the tab first, the current instance treats it as already processed.
+- **No decisions found**: A Decisions tab is still created with a "No decisions identified" note, preventing re-processing.
+
+## Development
+
+```bash
+# Build
+go build ./...
+
+# Test
+go test ./...
+
+# Lint
+go vet ./...
+
+# Run CI checks
+make ci
+```
+
+### Key Source Files
+
+| File | Purpose |
+|------|---------|
+| `internal/docs/service.go` | Transcript reading + Decisions tab creation |
+| `internal/gemini/client.go` | Decision extraction prompt + response parsing |
+| `internal/organizer/organizer.go` | Step 4 orchestration + doc collection |
+| `cmd/gcal-organizer/main.go` | Step 4 wiring in `run` command |
+| `pkg/models/models.go` | Decision and TranscriptHeading structs |

--- a/specs/008-decision-extraction/research.md
+++ b/specs/008-decision-extraction/research.md
@@ -1,0 +1,96 @@
+# Research: Decision Extraction from Meeting Transcripts
+
+**Feature**: `008-decision-extraction` | **Date**: 2026-02-26
+
+## R1: Google Docs API Tab Creation
+
+**Decision**: Use `AddDocumentTabRequest` via `Documents.BatchUpdate` to create the Decisions tab programmatically.
+
+**Rationale**: The Google Docs API v1 (Go SDK `google.golang.org/api@v0.264.0`) fully supports tab operations. `AddDocumentTabRequest` accepts a `TabProperties` struct with `Title`, `Index`, `IconEmoji`, and `ParentTabId`. The response (`AddDocumentTabResponse`) returns the server-assigned `TabId` needed for targeting subsequent content insertion requests.
+
+**Alternatives considered**:
+- Playwright browser automation (used for task assignment): Rejected — slower, more fragile, requires Chrome process. The Docs API has native write support and the OAuth scope (`documents`) already authorizes write operations.
+- Google Apps Script: Rejected — requires separate deployment and execution infrastructure.
+
+**Key finding**: Tab creation and content insertion require separate BatchUpdate calls because the `TabId` is only available in the response. A 2-write-call pattern is required: (1) create tab → get TabId, (2) insert content targeting that TabId.
+
+## R2: Cross-Tab Heading Links
+
+**Decision**: Use `Link.Heading` with `HeadingLink{Id, TabId}` to create clickable cross-tab links from the Decisions tab to Transcript timestamp headings.
+
+**Rationale**: The Docs API `Link` type supports 5 link targets. The `Heading` field (`*HeadingLink`) accepts both a heading ID and a target tab ID, enabling cross-tab navigation. Heading IDs are read-only (`ParagraphStyle.HeadingId`) and auto-assigned when a paragraph is styled as a heading. Since transcript H3 headings already exist, their IDs can be read from the initial `Documents.Get` call.
+
+**Alternatives considered**:
+- `Link.TabId` (tab-level link only): Rejected — navigates to the tab but not to a specific heading within it. Users need to land on the exact timestamp.
+- `Link.Bookmark` with `BookmarkLink`: Rejected — bookmarks cannot be created programmatically via the Docs API (no `CreateBookmarkRequest` exists).
+- `Link.Url` (external URL with anchor): Rejected — Google Docs internal navigation is better UX than opening a browser tab.
+
+**Key finding**: The H3 timestamp headings in Google Gemini transcripts have server-assigned `HeadingId` values accessible via `tab.DocumentTab.Body.Content[].Paragraph.ParagraphStyle.HeadingId`. These can be read in Pass 1 (GET) and used in Pass 3 (BatchUpdate) for link insertion.
+
+## R3: API Call Pattern
+
+**Decision**: 3 Google API calls per document: 1 GET + 2 BatchUpdates, plus 1 Gemini call.
+
+**Rationale**: The Docs API does not support forward-referencing response values within a single BatchUpdate. The server-assigned `TabId` from `AddDocumentTabRequest` is only available in `BatchUpdateDocumentResponse.Replies`, which is returned after the entire call completes. Therefore, content insertion targeting the new tab must be a separate call.
+
+**Call sequence**:
+1. `Documents.Get(docID)` — read document, extract Transcript tab content + H3 heading IDs, check for Decisions tab
+2. `Gemini.GenerateContent` — send transcript text, receive structured decisions JSON
+3. `Documents.BatchUpdate` — `AddDocumentTab` (create Decisions tab) → extract `TabId` from response
+4. `Documents.BatchUpdate` — `InsertText` + `UpdateParagraphStyle` + `CreateParagraphBullets` + `UpdateTextStyle` (all targeting new `TabId`)
+
+**Alternatives considered**:
+- Single BatchUpdate for everything: Not possible — see rationale above.
+- 4-call pattern (separate GET for heading IDs after styling): Not needed — transcript headings already exist from the initial GET. Only new headings in the Decisions tab would need a re-read, but we don't need to link *to* Decisions headings, only *from* them.
+
+## R4: Gemini Prompt Design for Decision Extraction
+
+**Decision**: Send the full transcript text with a structured prompt requesting JSON output with category, decision text, and associated timestamp.
+
+**Rationale**: Gemini 2.0 Flash supports 1M token context window, sufficient for any meeting transcript (a 2-hour meeting transcript is typically 20-40K tokens). The existing codebase pattern (`ExtractAssigneesFromCheckboxes`) sends structured prompts and parses JSON responses — the same pattern applies here.
+
+**Response format**: JSON array of objects:
+```json
+[
+  {
+    "category": "made",
+    "text": "Team will adopt the new CI/CD pipeline starting next sprint",
+    "timestamp": "12:34",
+    "context": "After discussing the three pipeline options, the team voted unanimously for GitHub Actions"
+  }
+]
+```
+
+**Alternatives considered**:
+- Two-pass summarize-then-extract: Rejected — adds latency and loses nuance. Full transcript analysis is more accurate.
+- Pattern-matching only (regex for "we decided", "let's defer"): Rejected — too brittle. Natural language is varied; AI analysis captures implicit decisions.
+
+## R5: Idempotency and Concurrency
+
+**Decision**: Check for existing "Decisions" tab via document read (primary gate), plus optimistic concurrency on tab creation (secondary gate).
+
+**Rationale**: The primary idempotency check reads all tabs from `doc.Tabs` and checks for `tab.TabProperties.Title == "Decisions"`. If found, the document is skipped. For concurrent instances, the `AddDocumentTab` call will fail if a tab with the same name was created by another instance between the read and write — this error is caught and treated as "already processed".
+
+**Alternatives considered**:
+- Distributed lock (Redis, file lock): Rejected — adds infrastructure complexity for a rare race condition in a single-user CLI tool.
+- Emoji marker in document: Rejected — less clean than tab presence check; the tab itself is the artifact.
+
+## R6: Attachment Title Matching
+
+**Decision**: Exact match for "Notes by Gemini"; suffix match for "- Transcript" (case-sensitive).
+
+**Rationale**: Google Gemini always names its meeting notes attachment exactly "Notes by Gemini". Standalone transcript documents follow the pattern `"[Meeting Title] - [Date] [Time] [TZ] - Transcript"` (e.g., "ComplyTime Standup - 2026/02/25 14:00 WET - Transcript"). Case-sensitive suffix matching with `strings.HasSuffix(title, "- Transcript")` is precise and avoids false positives.
+
+**Alternatives considered**:
+- Substring `strings.Contains`: Rejected — would match "Transcript Review Notes" or other unrelated documents.
+- Case-insensitive matching: Not needed — Google Gemini generates consistent casing.
+
+## R7: Document Collection and Deduplication
+
+**Decision**: Collect eligible documents during Step 2 (calendar sync) using a new `decisionDocIDs` map with per-event deduplication preferring "Notes by Gemini".
+
+**Rationale**: Follows the existing `notesDocIDs` pattern in the organizer (line 60 of organizer.go). During `SyncCalendarAttachments`, after iterating attachments for each event, the system checks for matching titles. If both "Notes by Gemini" and "- Transcript" are found on the same event, only the "Notes by Gemini" document ID is collected.
+
+**Alternatives considered**:
+- Separate scan pass over all documents: Rejected — wasteful; the calendar sync already iterates all events and attachments.
+- Reuse `notesDocIDs`: Not appropriate — different filter criteria and different downstream processing.

--- a/specs/008-decision-extraction/spec.md
+++ b/specs/008-decision-extraction/spec.md
@@ -1,0 +1,143 @@
+# Feature Specification: Decision Extraction from Meeting Transcripts
+
+**Feature Branch**: `008-decision-extraction`  
+**Created**: 2026-02-26  
+**Status**: Draft  
+**Input**: User description: "For all docs named ~'Notes by Gemini', with a 'Transcript' tab, add a tab named 'Decisions' with Gemini-extracted decisions linked to transcript timestamps. For all docs named ~'Transcript', add a 'Decisions' tab with the same."
+
+## User Scenarios & Testing *(mandatory)*
+
+### User Story 1 - Extract Decisions from Meeting Transcript (Priority: P1)
+
+As a meeting organizer, I want decisions from my meetings automatically extracted and categorized into a new "Decisions" tab so I can quickly review what was decided, what was deferred, and what remains open without re-reading the entire transcript.
+
+**Why this priority**: This is the core value proposition. Without decision extraction, the feature has no purpose. It delivers immediate time savings for anyone who runs recurring meetings and needs to track outcomes.
+
+**Independent Test**: Can be fully tested by running the workflow against a calendar event that has a "Notes by Gemini" attachment with a Transcript tab. The test verifies that a "Decisions" tab is created with categorized decisions.
+
+**Acceptance Scenarios**:
+
+1. **Given** a calendar event within the lookback window has a "Notes by Gemini" attachment containing a "Transcript" tab, **When** the workflow processes the event, **Then** a new "Decisions" tab is created in the same document with three sections: "Decisions Made", "Decisions Deferred", and "Open Items", each populated with relevant decisions extracted from the transcript.
+
+2. **Given** a calendar event within the lookback window has a standalone "Transcript" attachment (flat or tabbed document), **When** the workflow processes the event, **Then** a new "Decisions" tab is created in that document with the same three-section structure.
+
+3. **Given** a calendar event has both a "Notes by Gemini" and a standalone "Transcript" attachment, **When** the workflow processes the event, **Then** only the "Notes by Gemini" document is processed (deduplication).
+
+---
+
+### User Story 2 - Cross-Tab Timestamp Links (Priority: P2)
+
+As a meeting participant, I want each extracted decision to link back to the relevant timestamp in the transcript so I can verify the context and nuance of what was actually said.
+
+**Why this priority**: Links transform the Decisions tab from a static list into a navigable reference. Without them, users must manually search the transcript to find context, which significantly reduces the feature's value.
+
+**Independent Test**: Can be tested by clicking a decision's timestamp link in the Decisions tab and verifying it navigates to the correct heading in the Transcript tab.
+
+**Acceptance Scenarios**:
+
+1. **Given** a Decisions tab has been created with extracted decisions, **When** the user clicks a timestamp reference on any decision, **Then** the document navigates to the corresponding timestamp heading in the Transcript tab.
+
+2. **Given** the transcript uses H3 headings for timestamps (e.g., "12:34"), **When** decisions are extracted and linked, **Then** each decision is associated with the nearest preceding timestamp heading from the transcript.
+
+3. **Given** a transcript heading has no decisions associated with it, **When** the Decisions tab is generated, **Then** that timestamp is not referenced (no empty links).
+
+---
+
+### User Story 3 - Idempotent Processing (Priority: P3)
+
+As a user running the workflow on a schedule, I want documents that have already been processed to be skipped automatically so decisions are not duplicated or overwritten on subsequent runs.
+
+**Why this priority**: The workflow runs as a background service (hourly via launchd/systemd). Without idempotency, every run would create duplicate tabs or fail, requiring manual cleanup.
+
+**Independent Test**: Can be tested by running the workflow twice against the same document and verifying the second run skips it without errors.
+
+**Acceptance Scenarios**:
+
+1. **Given** a document already has a "Decisions" tab from a previous run, **When** the workflow encounters the same document again, **Then** it skips the document and logs that it was already processed.
+
+2. **Given** a document has a manually-created tab named "Decisions", **When** the workflow encounters this document, **Then** it treats the document as already processed and skips it.
+
+---
+
+### User Story 4 - Dry-Run and Ownership Controls (Priority: P3)
+
+As a cautious user, I want to preview what decisions would be extracted and which documents would be modified before committing changes, and I want to restrict processing to documents I own.
+
+**Why this priority**: Consistent with existing CLI behavior. The `--dry-run` and `--owned-only` flags are established patterns that users rely on for safe operation.
+
+**Independent Test**: Can be tested by running with `--dry-run` and verifying no documents are modified, and by running with `--owned-only` and verifying unowned documents are skipped.
+
+**Acceptance Scenarios**:
+
+1. **Given** the `--dry-run` flag is set, **When** the workflow identifies a transcript document eligible for processing, **Then** it logs the decisions that would be extracted and the tab that would be created without modifying the document.
+
+2. **Given** the `--owned-only` flag is set, **When** the workflow encounters a transcript document not owned by the authenticated user, **Then** it skips the document.
+
+---
+
+### Edge Cases
+
+- What happens when the transcript is empty or contains no meaningful dialogue?
+  - The system sends the transcript to the AI regardless. If the AI identifies no decisions, the Decisions tab is still created but with a note indicating no decisions were found.
+
+- What happens when the transcript contains no timestamp headings?
+  - Decisions are still extracted and listed, but without clickable timestamp links. A text-only timestamp approximation may be included if the AI can identify one from the transcript text.
+
+- What happens when the AI fails to parse the transcript (API error, timeout)?
+  - The document is skipped with a warning logged. The next run will attempt processing again since no Decisions tab was created (natural retry via idempotency).
+
+- What happens when the document has a "Decisions" tab but it is empty?
+  - The system treats the tab as existing and skips the document. The check is for tab presence, not content.
+
+- What happens when the meeting was very short and had no substantive discussion?
+  - The AI may return an empty list of decisions. The Decisions tab is created with a "No decisions identified" note. This marks the document as processed.
+
+- What happens when the transcript language is not English?
+  - The AI processes the transcript in whatever language it is written in. Decision extraction quality depends on the AI model's multilingual capabilities.
+
+## Requirements *(mandatory)*
+
+### Functional Requirements
+
+- **FR-001**: System MUST detect documents attached to calendar events with titles containing "Notes by Gemini" or "Transcript"
+- **FR-002**: System MUST deduplicate: when both a "Notes by Gemini" and a standalone "Transcript" document are attached to the same calendar event, only the "Notes by Gemini" document is processed
+- **FR-003**: System MUST locate the "Transcript" tab within a multi-tab document, or use the document body content for flat/single-tab documents
+- **FR-004**: System MUST extract the full text content from the transcript, including all timestamp headings and their positions
+- **FR-005**: System MUST skip documents that already have a tab named "Decisions" (idempotency check)
+- **FR-006**: System MUST send the full transcript text (no truncation) to the AI for decision extraction
+- **FR-007**: System MUST categorize each extracted decision as one of: "made", "deferred", or "open"
+- **FR-008**: System MUST associate each decision with the nearest preceding timestamp from the transcript
+- **FR-009**: System MUST create a new tab named "Decisions" in the processed document
+- **FR-010**: System MUST organize the Decisions tab into three sections with clear headings: "Decisions Made", "Decisions Deferred", and "Open Items"
+- **FR-011**: System MUST render each decision as a bullet point within its appropriate section
+- **FR-012**: System MUST create clickable links from each decision's timestamp reference to the corresponding timestamp heading in the Transcript tab
+- **FR-013**: System MUST respect the `--dry-run` flag by logging intended actions without modifying any documents
+- **FR-014**: System MUST respect the `--owned-only` flag by skipping documents not owned by the authenticated user
+- **FR-015**: System MUST process only documents attached to calendar events within the configured lookback window (`--days`)
+- **FR-016**: System MUST create a Decisions tab with a "No decisions identified" note when the AI finds no decisions in the transcript
+- **FR-017**: System MUST log a warning and skip the document when the AI call fails, allowing natural retry on subsequent runs
+
+### Assumptions
+
+- Transcript documents generated by Google Gemini use H3 headings for timestamps
+- The Google Docs write scope (`DocumentsScope`) is already authorized via existing OAuth configuration
+- The AI model configured in `GEMINI_MODEL` (default: `gemini-2.0-flash`) has sufficient context window for full meeting transcripts
+- Calendar event attachments include the document title, which is used for pattern matching
+
+### Key Entities
+
+- **Decision**: Represents a single decision extracted from a transcript. Attributes: category (made/deferred/open), description text, associated timestamp, brief context excerpt from the transcript
+- **TranscriptHeading**: Represents a timestamp heading in the transcript. Attributes: heading identifier (for linking), display text (e.g., "12:34"), position in the document
+- **TranscriptContent**: The full text of a transcript and its associated metadata (tab identifier, list of timestamp headings)
+
+## Success Criteria *(mandatory)*
+
+### Measurable Outcomes
+
+- **SC-001**: For every eligible transcript document processed, a "Decisions" tab is created containing categorized decisions within 30 seconds per document
+- **SC-002**: At least 90% of decisions identified by the AI are correctly categorized (made vs. deferred vs. open) when compared against manual review of 10 sample transcripts
+- **SC-003**: Every decision with an identifiable transcript timestamp includes a working clickable link to the correct heading in the Transcript tab
+- **SC-004**: Running the workflow twice on the same set of documents produces zero duplicate Decisions tabs (100% idempotency)
+- **SC-005**: Users can review meeting decisions in under 1 minute by reading the Decisions tab, compared to 10+ minutes scanning the full transcript
+- **SC-006**: All existing workflow steps (organize, sync-calendar, assign-tasks) continue to function without regression
+- **SC-007**: The feature processes documents only within the configured lookback window, with zero documents processed outside that window

--- a/specs/008-decision-extraction/spec.md
+++ b/specs/008-decision-extraction/spec.md
@@ -2,7 +2,7 @@
 
 **Feature Branch**: `008-decision-extraction`  
 **Created**: 2026-02-26  
-**Status**: Draft  
+**Status**: Implemented  
 **Input**: User description: "For all docs named ~'Notes by Gemini', with a 'Transcript' tab, add a tab named 'Decisions' with Gemini-extracted decisions linked to transcript timestamps. For all docs named ~'Transcript', add a 'Decisions' tab with the same."
 
 ## User Scenarios & Testing *(mandatory)*

--- a/specs/008-decision-extraction/spec.md
+++ b/specs/008-decision-extraction/spec.md
@@ -19,9 +19,9 @@ As a meeting organizer, I want decisions from my meetings automatically extracte
 
 1. **Given** a calendar event within the lookback window has a "Notes by Gemini" attachment containing a "Transcript" tab, **When** the workflow processes the event, **Then** a new "Decisions" tab is created in the same document with three sections: "Decisions Made", "Decisions Deferred", and "Open Items", each populated with relevant decisions extracted from the transcript.
 
-2. **Given** a calendar event within the lookback window has a standalone "Transcript" attachment (flat or tabbed document), **When** the workflow processes the event, **Then** a new "Decisions" tab is created in that document with the same three-section structure.
+2. **Given** a calendar event within the lookback window has an attachment whose title ends with "- Transcript" (e.g., "ComplyTime Standup - 2026/02/25 14:00 WET - Transcript"), **When** the workflow processes the event, **Then** a new "Decisions" tab is created in that document with the same three-section structure.
 
-3. **Given** a calendar event has both a "Notes by Gemini" and a standalone "Transcript" attachment, **When** the workflow processes the event, **Then** only the "Notes by Gemini" document is processed (deduplication).
+3. **Given** a calendar event has both a "Notes by Gemini" attachment and a "- Transcript" attachment, **When** the workflow processes the event, **Then** only the "Notes by Gemini" document is processed (deduplication).
 
 ---
 
@@ -95,12 +95,15 @@ As a cautious user, I want to preview what decisions would be extracted and whic
 - What happens when the transcript language is not English?
   - The AI processes the transcript in whatever language it is written in. Decision extraction quality depends on the AI model's multilingual capabilities.
 
+- What happens when two workflow instances process the same document concurrently?
+  - The system uses optimistic concurrency: it attempts to create the Decisions tab, and if the API rejects the request because a tab with that name already exists (created by the other instance), the system treats it as "already processed" and skips the document gracefully.
+
 ## Requirements *(mandatory)*
 
 ### Functional Requirements
 
-- **FR-001**: System MUST detect documents attached to calendar events with titles containing "Notes by Gemini" or "Transcript"
-- **FR-002**: System MUST deduplicate: when both a "Notes by Gemini" and a standalone "Transcript" document are attached to the same calendar event, only the "Notes by Gemini" document is processed
+- **FR-001**: System MUST detect documents attached to calendar events where the attachment title is exactly "Notes by Gemini" or ends with "- Transcript" (suffix match)
+- **FR-002**: System MUST deduplicate: when both a "Notes by Gemini" and a standalone "- Transcript" document are attached to the same calendar event, only the "Notes by Gemini" document is processed
 - **FR-003**: System MUST locate the "Transcript" tab within a multi-tab document, or use the document body content for flat/single-tab documents
 - **FR-004**: System MUST extract the full text content from the transcript, including all timestamp headings and their positions
 - **FR-005**: System MUST skip documents that already have a tab named "Decisions" (idempotency check)
@@ -116,6 +119,7 @@ As a cautious user, I want to preview what decisions would be extracted and whic
 - **FR-015**: System MUST process only documents attached to calendar events within the configured lookback window (`--days`)
 - **FR-016**: System MUST create a Decisions tab with a "No decisions identified" note when the AI finds no decisions in the transcript
 - **FR-017**: System MUST log a warning and skip the document when the AI call fails, allowing natural retry on subsequent runs
+- **FR-018**: System MUST handle concurrent processing gracefully: if tab creation fails because a "Decisions" tab was created by another instance, the system treats the document as already processed and skips it
 
 ### Assumptions
 
@@ -141,3 +145,10 @@ As a cautious user, I want to preview what decisions would be extracted and whic
 - **SC-005**: Users can review meeting decisions in under 1 minute by reading the Decisions tab, compared to 10+ minutes scanning the full transcript
 - **SC-006**: All existing workflow steps (organize, sync-calendar, assign-tasks) continue to function without regression
 - **SC-007**: The feature processes documents only within the configured lookback window, with zero documents processed outside that window
+
+## Clarifications
+
+### Session 2026-02-26
+
+- Q: How strict should title matching be for detecting transcript documents? → A: Attachment title must be exactly "Notes by Gemini" (exact match) or end with "- Transcript" (suffix match). Example: "ComplyTime Standup - 2026/02/25 14:00 WET - Transcript".
+- Q: How should the system handle concurrent processing of the same document? → A: Optimistic concurrency. Attempt tab creation; if the API rejects due to a duplicate tab name, treat as "already processed" and skip.

--- a/specs/008-decision-extraction/tasks.md
+++ b/specs/008-decision-extraction/tasks.md
@@ -21,7 +21,7 @@
 
 - [ ] T001 [P] Add `Decision` struct (Category, Text, Timestamp, Context fields) and `TranscriptHeading` struct (HeadingID, Text, Index fields) to `pkg/models/models.go` — per data-model.md entity definitions
 - [ ] T002 [P] Add `TranscriptContent` struct (TabID, FullText, Headings fields) to `pkg/models/models.go` — aggregates transcript tab metadata
-- [ ] T003 Add `decisionDocIDs` field (`map[string]string` mapping docID→source) to `Organizer` struct and `GetDecisionDocIDs()` method to `internal/organizer/organizer.go` — follows existing `notesDocIDs` pattern at line 60
+- [ ] T003 Add `decisionDocIDs` field (`map[string]string` mapping docID→source) to `Organizer` struct and `GetDecisionDocIDs()` method to `internal/organizer/organizer.go` — uses `map[string]string` (unlike `notesDocIDs`'s `map[string]bool`) because the source value (`"notes-by-gemini"` or `"transcript"`) is needed for per-event deduplication and logging
 
 ---
 
@@ -38,7 +38,7 @@
 
 ### Implementation
 
-- [ ] T006 Add decision document collection logic to `SyncCalendarAttachments` in `internal/organizer/organizer.go` — after existing `notesDocIDs` collection (line 288): for each event, check attachment titles for exact "Notes by Gemini" or `strings.HasSuffix(title, "- Transcript")`, apply per-event deduplication, check `--owned-only` via `IsFileOwned`, store in `decisionDocIDs` map (FR-001, FR-002, FR-014, R6, R7)
+- [ ] T006 Add decision document collection logic to `SyncCalendarAttachments` in `internal/organizer/organizer.go` — after existing `notesDocIDs` collection (line 288): for each event, check attachment titles for exact "Notes by Gemini" or `strings.HasSuffix(title, "- Transcript")`, apply per-event deduplication, check `--owned-only` via `IsFileOwned`, store in `decisionDocIDs` map (FR-001, FR-002, FR-014, FR-015, R6, R7)
 - [ ] T007 Implement `ExtractDecisions(ctx, transcriptText string) ([]models.Decision, error)` method on `gemini.Client` in `internal/gemini/client.go` — build prompt requesting JSON array with category/text/timestamp/context fields, call `c.client.Models.GenerateContent` with retry, parse response via new `parseDecisionsResponse` helper (FR-006, FR-007, R4)
 - [ ] T008 Implement `parseDecisionsResponse(responseText string) ([]models.Decision, error)` helper in `internal/gemini/client.go` — strip markdown code fences, extract JSON array via regex, unmarshal into `[]Decision`, filter empty text, validate/default category (data-model.md parsing rules)
 - [ ] T009 Run `go test ./internal/organizer/... ./internal/gemini/...` and verify T004, T005 pass. Run `go vet ./...` and `gofmt -l .`
@@ -55,12 +55,12 @@
 
 ### Tests for User Story 1
 
-- [ ] T010 [P] [US1] Write `TestExtractTranscriptContent` table-driven test in `internal/docs/service_test.go` — verify: finds "Transcript" tab in multi-tab doc, falls back to body content for single-tab doc, returns empty TranscriptContent for doc with no transcript, extracts full text and H3 heading metadata (FR-003, FR-004)
+- [ ] T010 [P] [US1] Write `TestExtractTranscriptContent` table-driven test in `internal/docs/service_test.go` — verify: finds "Transcript" tab in multi-tab doc, uses first tab's content for single-tab doc (via `includeTabsContent=true`), returns empty TranscriptContent for doc with no transcript, extracts full text and H3 heading metadata (FR-003, FR-004)
 - [ ] T011 [P] [US1] Write `TestCreateDecisionsTab` table-driven test in `internal/docs/service_test.go` — verify: creates tab with correct title "Decisions", inserts three H2 section headings, inserts decision bullet text under correct section, handles empty decisions list with "No decisions identified" note (FR-009, FR-010, FR-011, FR-016)
 
 ### Implementation for User Story 1
 
-- [ ] T012 [US1] Implement `ExtractTranscriptContent(ctx, docID string) (*models.TranscriptContent, error)` in `internal/docs/service.go` — call `GetDocument`, iterate `doc.Tabs` to find tab with title "Transcript", extract `DocumentTab.Body.Content` text and H3 headings (ParagraphStyle.NamedStyleType == "HEADING_3") with HeadingID/Text/Index, fall back to `doc.Body.Content` for single-tab docs (FR-003, FR-004, R2)
+- [ ] T012 [US1] Implement `ExtractTranscriptContent(ctx, docID string) (*models.TranscriptContent, error)` in `internal/docs/service.go` — call `Documents.Get(docID)` with `includeTabsContent=true`, always iterate `doc.Tabs` (single-tab docs have one tab entry): find tab with title "Transcript" or use the sole tab for single-tab docs, extract `tab.DocumentTab.Body.Content` text and H3 headings (ParagraphStyle.NamedStyleType == "HEADING_3") with HeadingID/Text/Index (FR-003, FR-004, R2)
 - [ ] T013 [US1] Implement `CreateDecisionsTab(ctx, docID string, decisions []models.Decision, transcript *models.TranscriptContent) error` in `internal/docs/service.go` — BatchUpdate #1: `AddDocumentTab` with title "Decisions", extract TabId from response; BatchUpdate #2: `InsertText` for section headings ("Decisions Made\n", "Decisions Deferred\n", "Open Items\n") and decision bullets, `UpdateParagraphStyle` to style headings as HEADING_2, `CreateParagraphBullets` for decision items; handle empty decisions with "No decisions identified" note (FR-009, FR-010, FR-011, FR-016, R1, R3)
 - [ ] T014 [US1] Add `DocsService` interface to `internal/organizer/organizer.go` with methods: `ExtractTranscriptContent(ctx, docID) (*models.TranscriptContent, error)`, `HasDecisionsTab(ctx, docID) (bool, error)`, `CreateDecisionsTab(ctx, docID, decisions, transcript) error`
 - [ ] T015 [US1] Implement `ExtractDecisionsForDoc(ctx, docID string, docsSvc DocsService, geminiClient *gemini.Client, dryRun bool) error` orchestration function in `internal/organizer/organizer.go` — coordinates: extract transcript → call Gemini → create tab; skip on AI failure with warning (FR-017); log actions for dry-run (FR-013)
@@ -123,7 +123,7 @@
 
 ### Implementation for User Story 4
 
-- [ ] T030 [US4] Add dry-run guard to `ExtractDecisionsForDoc` in `internal/organizer/organizer.go` — when `dryRun` is true: extract transcript and call Gemini (to show what would happen), log the decisions that would be created and the tab that would be added, but skip both BatchUpdate calls; display document title and decision count (FR-013)
+- [ ] T030 [US4] Add dry-run guard to `ExtractDecisionsForDoc` in `internal/organizer/organizer.go` — when `dryRun` is true: skip Gemini and all BatchUpdate calls; only log eligible document title and transcript size (e.g., "Would extract decisions from [doc title] (N characters)"); consistent with Step 3's dry-run pattern which skips expensive operations (FR-013)
 - [ ] T031 [US4] Verify `--owned-only` filtering in `SyncCalendarAttachments` decision collection (from T006) — ensure `IsFileOwned` check gates entry into `decisionDocIDs` map when `o.config.OwnedOnly` is true (FR-014); already implemented in T006 but verify with manual test
 - [ ] T032 [US4] Add dry-run and owned-only output formatting in Step 4 block of `cmd/gcal-organizer/main.go` — match existing Step 3 patterns: "Would extract decisions from N documents" for dry-run, "No owned transcript documents found" when `--owned-only` filters all docs
 
@@ -137,9 +137,10 @@
 
 - [ ] T033 [P] Update README.md with Step 4 documentation — describe decision extraction behavior, supported document patterns, example output
 - [ ] T034 [P] Update AGENTS.md project structure if needed — verify `internal/docs/` description reflects write capability
-- [ ] T035 Run full CI checks: `go build ./... && go test ./... && go vet ./... && gofmt -l . && go mod tidy` — verify no regressions (SC-006)
-- [ ] T036 Run `gcal-organizer run --dry-run` against a real calendar with transcript attachments — manual validation of end-to-end flow
-- [ ] T037 Verify quickstart.md scenarios work as documented in `specs/008-decision-extraction/quickstart.md`
+- [ ] T035 [P] Update `man/gcal-organizer.1` man page with Step 4 behavior — add decision extraction description to the workflow section, per constitution documentation requirement
+- [ ] T036 Run `make ci` — verify no regressions and all quality gates pass (SC-006, constitution Quality Gates)
+- [ ] T037 Run `gcal-organizer run --dry-run` against a real calendar with transcript attachments — manual validation of end-to-end flow
+- [ ] T038 Verify quickstart.md scenarios work as documented in `specs/008-decision-extraction/quickstart.md`
 
 ---
 
@@ -178,7 +179,7 @@
 - T010, T011 can run in parallel (different test functions)
 - T019, T020 can run in parallel (different test functions)
 - T024, T025 can run in parallel (different test functions)
-- T033, T034 can run in parallel (different documentation files)
+- T033, T034, T035 can run in parallel (different documentation files)
 - US3 and US4 can run in parallel after US1 completes (independent guards on the same function)
 
 ---

--- a/specs/008-decision-extraction/tasks.md
+++ b/specs/008-decision-extraction/tasks.md
@@ -1,0 +1,247 @@
+# Tasks: Decision Extraction from Meeting Transcripts
+
+**Input**: Design documents from `/specs/008-decision-extraction/`
+**Prerequisites**: plan.md (required), spec.md (required), research.md, data-model.md
+
+**Tests**: Included per Constitution Principle III (Test-Driven Development).
+
+**Organization**: Tasks are grouped by user story to enable independent implementation and testing of each story.
+
+## Format: `[ID] [P?] [Story] Description`
+
+- **[P]**: Can run in parallel (different files, no dependencies)
+- **[Story]**: Which user story this task belongs to (e.g., US1, US2, US3, US4)
+- Include exact file paths in descriptions
+
+---
+
+## Phase 1: Setup (Shared Infrastructure)
+
+**Purpose**: Add shared data models and types needed by all user stories
+
+- [ ] T001 [P] Add `Decision` struct (Category, Text, Timestamp, Context fields) and `TranscriptHeading` struct (HeadingID, Text, Index fields) to `pkg/models/models.go` — per data-model.md entity definitions
+- [ ] T002 [P] Add `TranscriptContent` struct (TabID, FullText, Headings fields) to `pkg/models/models.go` — aggregates transcript tab metadata
+- [ ] T003 Add `decisionDocIDs` field (`map[string]string` mapping docID→source) to `Organizer` struct and `GetDecisionDocIDs()` method to `internal/organizer/organizer.go` — follows existing `notesDocIDs` pattern at line 60
+
+---
+
+## Phase 2: Foundational (Blocking Prerequisites)
+
+**Purpose**: Document collection during calendar sync and Gemini decision extraction — MUST complete before any user story
+
+**CRITICAL**: No user story work can begin until this phase is complete
+
+### Tests
+
+- [ ] T004 [P] Write `TestDecisionDocCollection` table-driven test in `internal/organizer/organizer_test.go` — verify attachment title matching: exact match "Notes by Gemini", suffix match "- Transcript", non-matching titles rejected, per-event deduplication preferring "Notes by Gemini" (FR-001, FR-002)
+- [ ] T005 [P] Write `TestParseDecisionsResponse` table-driven test in `internal/gemini/client_test.go` — verify JSON parsing of decision extraction response: valid array, markdown-wrapped response, empty decisions filtered, invalid category defaults to "open", empty text filtered, empty array (data-model.md parsing rules)
+
+### Implementation
+
+- [ ] T006 Add decision document collection logic to `SyncCalendarAttachments` in `internal/organizer/organizer.go` — after existing `notesDocIDs` collection (line 288): for each event, check attachment titles for exact "Notes by Gemini" or `strings.HasSuffix(title, "- Transcript")`, apply per-event deduplication, check `--owned-only` via `IsFileOwned`, store in `decisionDocIDs` map (FR-001, FR-002, FR-014, R6, R7)
+- [ ] T007 Implement `ExtractDecisions(ctx, transcriptText string) ([]models.Decision, error)` method on `gemini.Client` in `internal/gemini/client.go` — build prompt requesting JSON array with category/text/timestamp/context fields, call `c.client.Models.GenerateContent` with retry, parse response via new `parseDecisionsResponse` helper (FR-006, FR-007, R4)
+- [ ] T008 Implement `parseDecisionsResponse(responseText string) ([]models.Decision, error)` helper in `internal/gemini/client.go` — strip markdown code fences, extract JSON array via regex, unmarshal into `[]Decision`, filter empty text, validate/default category (data-model.md parsing rules)
+- [ ] T009 Run `go test ./internal/organizer/... ./internal/gemini/...` and verify T004, T005 pass. Run `go vet ./...` and `gofmt -l .`
+
+**Checkpoint**: Document collection and Gemini decision extraction work independently. Foundation ready for user story implementation.
+
+---
+
+## Phase 3: User Story 1 — Extract Decisions from Meeting Transcript (Priority: P1) MVP
+
+**Goal**: For each eligible transcript document, read the transcript, extract decisions via Gemini, create a "Decisions" tab with three categorized sections.
+
+**Independent Test**: Run workflow against a calendar event with a "Notes by Gemini" attachment containing a Transcript tab. Verify a "Decisions" tab is created with "Decisions Made", "Decisions Deferred", and "Open Items" sections.
+
+### Tests for User Story 1
+
+- [ ] T010 [P] [US1] Write `TestExtractTranscriptContent` table-driven test in `internal/docs/service_test.go` — verify: finds "Transcript" tab in multi-tab doc, falls back to body content for single-tab doc, returns empty TranscriptContent for doc with no transcript, extracts full text and H3 heading metadata (FR-003, FR-004)
+- [ ] T011 [P] [US1] Write `TestCreateDecisionsTab` table-driven test in `internal/docs/service_test.go` — verify: creates tab with correct title "Decisions", inserts three H2 section headings, inserts decision bullet text under correct section, handles empty decisions list with "No decisions identified" note (FR-009, FR-010, FR-011, FR-016)
+
+### Implementation for User Story 1
+
+- [ ] T012 [US1] Implement `ExtractTranscriptContent(ctx, docID string) (*models.TranscriptContent, error)` in `internal/docs/service.go` — call `GetDocument`, iterate `doc.Tabs` to find tab with title "Transcript", extract `DocumentTab.Body.Content` text and H3 headings (ParagraphStyle.NamedStyleType == "HEADING_3") with HeadingID/Text/Index, fall back to `doc.Body.Content` for single-tab docs (FR-003, FR-004, R2)
+- [ ] T013 [US1] Implement `CreateDecisionsTab(ctx, docID string, decisions []models.Decision, transcript *models.TranscriptContent) error` in `internal/docs/service.go` — BatchUpdate #1: `AddDocumentTab` with title "Decisions", extract TabId from response; BatchUpdate #2: `InsertText` for section headings ("Decisions Made\n", "Decisions Deferred\n", "Open Items\n") and decision bullets, `UpdateParagraphStyle` to style headings as HEADING_2, `CreateParagraphBullets` for decision items; handle empty decisions with "No decisions identified" note (FR-009, FR-010, FR-011, FR-016, R1, R3)
+- [ ] T014 [US1] Add `DocsService` interface to `internal/organizer/organizer.go` with methods: `ExtractTranscriptContent(ctx, docID) (*models.TranscriptContent, error)`, `HasDecisionsTab(ctx, docID) (bool, error)`, `CreateDecisionsTab(ctx, docID, decisions, transcript) error`
+- [ ] T015 [US1] Implement `ExtractDecisionsForDoc(ctx, docID string, docsSvc DocsService, geminiClient *gemini.Client, dryRun bool) error` orchestration function in `internal/organizer/organizer.go` — coordinates: extract transcript → call Gemini → create tab; skip on AI failure with warning (FR-017); log actions for dry-run (FR-013)
+- [ ] T016 [US1] Wire Step 4 into `runCmd.RunE` in `cmd/gcal-organizer/main.go` — after Step 3 block (line ~143) and before `PrintSummary`: get `org.GetDecisionDocIDs()`, iterate, call `initDocsAndGemini` + `ExtractDecisionsForDoc` per doc, aggregate stats, handle dry-run logging
+- [ ] T017 [US1] Add decision stats fields (`DecisionsProcessed`, `DecisionsSkipped`, `DecisionsFailed`) to `Stats` struct and `AddDecisionStats` method in `internal/organizer/organizer.go`; update `PrintSummary` to include decision extraction results
+- [ ] T018 [US1] Run `go test ./...` and verify all tests pass. Run `go build ./...` and `go vet ./...`
+
+**Checkpoint**: Decision extraction is fully functional. Documents get a "Decisions" tab with categorized decisions (without cross-tab links yet). MVP complete.
+
+---
+
+## Phase 4: User Story 2 — Cross-Tab Timestamp Links (Priority: P2)
+
+**Goal**: Each decision's timestamp text becomes a clickable link navigating to the corresponding H3 heading in the Transcript tab.
+
+**Independent Test**: Click a decision's timestamp link in the Decisions tab and verify it navigates to the correct heading in the Transcript tab.
+
+### Tests for User Story 2
+
+- [ ] T019 [P] [US2] Write `TestTimestampToHeadingMatch` table-driven test in `internal/docs/service_test.go` — verify: exact timestamp match returns correct HeadingID, nearest preceding heading found when no exact match, no headings returns nil, multiple headings with same prefix handled correctly (FR-008, data-model.md timestamp matching rules)
+- [ ] T020 [P] [US2] Write `TestCreateDecisionsTabWithLinks` test in `internal/docs/service_test.go` — verify: `UpdateTextStyle` requests include `Link.Heading` with correct `HeadingLink{Id, TabId}` for each decision with a matched timestamp; decisions without matched timestamps have no link applied (FR-012)
+
+### Implementation for User Story 2
+
+- [ ] T021 [US2] Implement `matchTimestampToHeading(timestamp string, headings []models.TranscriptHeading) *models.TranscriptHeading` helper in `internal/docs/service.go` — find heading whose text contains the decision's timestamp; if no exact match, find nearest preceding by document position; return nil if no headings (FR-008, data-model.md timestamp matching)
+- [ ] T022 [US2] Extend `CreateDecisionsTab` in `internal/docs/service.go` to add cross-tab heading links — in BatchUpdate #2: for each decision with a matched timestamp heading, add `UpdateTextStyleRequest` with `TextStyle.Link.Heading = &HeadingLink{Id: heading.HeadingID, TabId: transcript.TabID}` targeting the timestamp text range within the decision bullet (FR-012, R2)
+- [ ] T023 [US2] Run `go test ./internal/docs/...` and verify T019, T020 pass alongside existing tests
+
+**Checkpoint**: Decisions now have clickable cross-tab timestamp links. US1 + US2 both work independently.
+
+---
+
+## Phase 5: User Story 3 — Idempotent Processing (Priority: P3)
+
+**Goal**: Documents with an existing "Decisions" tab are skipped. Concurrent tab creation is handled gracefully.
+
+**Independent Test**: Run the workflow twice against the same document and verify the second run skips without errors.
+
+### Tests for User Story 3
+
+- [ ] T024 [P] [US3] Write `TestHasDecisionsTab` table-driven test in `internal/docs/service_test.go` — verify: returns true when "Decisions" tab exists, returns false when no "Decisions" tab, returns true for manually-created "Decisions" tab (FR-005)
+- [ ] T025 [P] [US3] Write `TestOptimisticConcurrency` test in `internal/docs/service_test.go` — verify: when `AddDocumentTab` returns an error indicating duplicate tab, `CreateDecisionsTab` returns a sentinel error that the caller treats as "already processed" (FR-018, R5)
+
+### Implementation for User Story 3
+
+- [ ] T026 [US3] Implement `HasDecisionsTab(ctx, docID string) (bool, error)` in `internal/docs/service.go` — call `GetDocument`, iterate `doc.Tabs` checking for `tab.TabProperties.Title == "Decisions"`, return true/false (FR-005, R5)
+- [ ] T027 [US3] Add idempotency check to `ExtractDecisionsForDoc` in `internal/organizer/organizer.go` — call `docsSvc.HasDecisionsTab` before processing; if true, log "already processed" and increment `DecisionsSkipped` stat; return early (FR-005)
+- [ ] T028 [US3] Add optimistic concurrency handling to `CreateDecisionsTab` in `internal/docs/service.go` — if `AddDocumentTab` BatchUpdate returns an error, check if error indicates duplicate tab name; if so, return `ErrDecisionsTabExists` sentinel; caller in `ExtractDecisionsForDoc` catches this and treats as "already processed" (FR-018, R5)
+- [ ] T029 [US3] Run `go test ./...` and verify all tests pass including idempotency scenarios
+
+**Checkpoint**: Idempotent and concurrency-safe. Multiple runs produce zero duplicates (SC-004).
+
+---
+
+## Phase 6: User Story 4 — Dry-Run and Ownership Controls (Priority: P3)
+
+**Goal**: `--dry-run` previews without mutating; `--owned-only` skips unowned documents.
+
+**Independent Test**: Run with `--dry-run` and verify no documents modified. Run with `--owned-only` and verify unowned docs skipped.
+
+### Implementation for User Story 4
+
+- [ ] T030 [US4] Add dry-run guard to `ExtractDecisionsForDoc` in `internal/organizer/organizer.go` — when `dryRun` is true: extract transcript and call Gemini (to show what would happen), log the decisions that would be created and the tab that would be added, but skip both BatchUpdate calls; display document title and decision count (FR-013)
+- [ ] T031 [US4] Verify `--owned-only` filtering in `SyncCalendarAttachments` decision collection (from T006) — ensure `IsFileOwned` check gates entry into `decisionDocIDs` map when `o.config.OwnedOnly` is true (FR-014); already implemented in T006 but verify with manual test
+- [ ] T032 [US4] Add dry-run and owned-only output formatting in Step 4 block of `cmd/gcal-organizer/main.go` — match existing Step 3 patterns: "Would extract decisions from N documents" for dry-run, "No owned transcript documents found" when `--owned-only` filters all docs
+
+**Checkpoint**: All four user stories complete. Full feature ready for polish.
+
+---
+
+## Phase 7: Polish & Cross-Cutting Concerns
+
+**Purpose**: Documentation, cleanup, and validation across all stories
+
+- [ ] T033 [P] Update README.md with Step 4 documentation — describe decision extraction behavior, supported document patterns, example output
+- [ ] T034 [P] Update AGENTS.md project structure if needed — verify `internal/docs/` description reflects write capability
+- [ ] T035 Run full CI checks: `go build ./... && go test ./... && go vet ./... && gofmt -l . && go mod tidy` — verify no regressions (SC-006)
+- [ ] T036 Run `gcal-organizer run --dry-run` against a real calendar with transcript attachments — manual validation of end-to-end flow
+- [ ] T037 Verify quickstart.md scenarios work as documented in `specs/008-decision-extraction/quickstart.md`
+
+---
+
+## Dependencies & Execution Order
+
+### Phase Dependencies
+
+- **Setup (Phase 1)**: No dependencies — can start immediately
+- **Foundational (Phase 2)**: Depends on Setup completion — BLOCKS all user stories
+- **User Stories (Phases 3-6)**: All depend on Foundational phase completion
+  - US1 (Phase 3): Independent — no story dependencies
+  - US2 (Phase 4): Extends US1's `CreateDecisionsTab` with link insertion
+  - US3 (Phase 5): Adds guard to US1's `ExtractDecisionsForDoc`
+  - US4 (Phase 6): Adds guard to US1's `ExtractDecisionsForDoc`
+- **Polish (Phase 7)**: Depends on all user stories being complete
+
+### User Story Dependencies
+
+- **US1 (P1)**: Can start after Foundational (Phase 2) — no dependencies on other stories
+- **US2 (P2)**: Extends US1's `CreateDecisionsTab` — requires US1 complete
+- **US3 (P3)**: Adds idempotency guard to US1's flow — requires US1 complete; independent of US2
+- **US4 (P3)**: Adds dry-run/ownership guards to US1's flow — requires US1 complete; independent of US2, US3
+
+### Within Each User Story
+
+- Tests MUST be written and FAIL before implementation
+- Models/types before service methods
+- Service methods before orchestration
+- Orchestration before CLI wiring
+- Run tests after each implementation task
+
+### Parallel Opportunities
+
+- T001, T002 can run in parallel (different structs in same file, no conflicts)
+- T004, T005 can run in parallel (different test files)
+- T010, T011 can run in parallel (different test functions)
+- T019, T020 can run in parallel (different test functions)
+- T024, T025 can run in parallel (different test functions)
+- T033, T034 can run in parallel (different documentation files)
+- US3 and US4 can run in parallel after US1 completes (independent guards on the same function)
+
+---
+
+## Parallel Example: User Story 1
+
+```bash
+# Launch tests for US1 together:
+Task: "T010 — TestExtractTranscriptContent in internal/docs/service_test.go"
+Task: "T011 — TestCreateDecisionsTab in internal/docs/service_test.go"
+
+# Then implement service methods in parallel:
+Task: "T012 — ExtractTranscriptContent in internal/docs/service.go"
+Task: "T013 — CreateDecisionsTab in internal/docs/service.go"
+
+# Then orchestration (depends on T012, T013):
+Task: "T014 — DocsService interface in internal/organizer/organizer.go"
+Task: "T015 — ExtractDecisionsForDoc in internal/organizer/organizer.go"
+Task: "T016 — Wire Step 4 into runCmd in cmd/gcal-organizer/main.go"
+```
+
+---
+
+## Implementation Strategy
+
+### MVP First (User Story 1 Only)
+
+1. Complete Phase 1: Setup (T001-T003)
+2. Complete Phase 2: Foundational (T004-T009) — CRITICAL
+3. Complete Phase 3: User Story 1 (T010-T018)
+4. **STOP and VALIDATE**: Decisions tab created with categorized bullets — no links yet
+5. Deploy/demo if ready — core value delivered
+
+### Incremental Delivery
+
+1. Setup + Foundational → Foundation ready
+2. Add US1 → Decisions tab with categories → Deploy (MVP!)
+3. Add US2 → Cross-tab timestamp links → Deploy (full experience)
+4. Add US3 → Idempotent processing → Deploy (production-safe)
+5. Add US4 → Dry-run and ownership controls → Deploy (complete)
+6. Polish → Documentation and validation → Final release
+
+### Parallel Team Strategy
+
+With multiple developers:
+
+1. Team completes Setup + Foundational together
+2. Once Foundational is done:
+   - Developer A: User Story 1
+3. Once US1 is done:
+   - Developer A: User Story 2
+   - Developer B: User Story 3 (parallel — independent guard)
+   - Developer C: User Story 4 (parallel — independent guard)
+4. Stories complete and integrate independently
+
+---
+
+## Notes
+
+- [P] tasks = different files, no dependencies
+- [Story] label maps task to specific user story for traceability
+- Each user story should be independently completable and testable
+- Verify tests fail before implementing
+- Commit after each task or logical group
+- Stop at any checkpoint to validate story independently
+- Constitution Principle III mandates TDD — tests included in all phases

--- a/specs/008-decision-extraction/tasks.md
+++ b/specs/008-decision-extraction/tasks.md
@@ -19,9 +19,9 @@
 
 **Purpose**: Add shared data models and types needed by all user stories
 
-- [ ] T001 [P] Add `Decision` struct (Category, Text, Timestamp, Context fields) and `TranscriptHeading` struct (HeadingID, Text, Index fields) to `pkg/models/models.go` — per data-model.md entity definitions
-- [ ] T002 [P] Add `TranscriptContent` struct (TabID, FullText, Headings fields) to `pkg/models/models.go` — aggregates transcript tab metadata
-- [ ] T003 Add `decisionDocIDs` field (`map[string]string` mapping docID→source) to `Organizer` struct and `GetDecisionDocIDs()` method to `internal/organizer/organizer.go` — uses `map[string]string` (unlike `notesDocIDs`'s `map[string]bool`) because the source value (`"notes-by-gemini"` or `"transcript"`) is needed for per-event deduplication and logging
+- [x] T001 [P] Add `Decision` struct (Category, Text, Timestamp, Context fields) and `TranscriptHeading` struct (HeadingID, Text, Index fields) to `pkg/models/models.go` — per data-model.md entity definitions
+- [x] T002 [P] Add `TranscriptContent` struct (TabID, FullText, Headings fields) to `pkg/models/models.go` — aggregates transcript tab metadata
+- [x] T003 Add `decisionDocIDs` field (`map[string]string` mapping docID→source) to `Organizer` struct and `GetDecisionDocIDs()` method to `internal/organizer/organizer.go` — uses `map[string]string` (unlike `notesDocIDs`'s `map[string]bool`) because the source value (`"notes-by-gemini"` or `"transcript"`) is needed for per-event deduplication and logging
 
 ---
 
@@ -33,15 +33,15 @@
 
 ### Tests
 
-- [ ] T004 [P] Write `TestDecisionDocCollection` table-driven test in `internal/organizer/organizer_test.go` — verify attachment title matching: exact match "Notes by Gemini", suffix match "- Transcript", non-matching titles rejected, per-event deduplication preferring "Notes by Gemini" (FR-001, FR-002)
-- [ ] T005 [P] Write `TestParseDecisionsResponse` table-driven test in `internal/gemini/client_test.go` — verify JSON parsing of decision extraction response: valid array, markdown-wrapped response, empty decisions filtered, invalid category defaults to "open", empty text filtered, empty array (data-model.md parsing rules)
+- [x] T004 [P] Write `TestDecisionDocCollection` table-driven test in `internal/organizer/organizer_test.go` — verify attachment title matching: exact match "Notes by Gemini", suffix match "- Transcript", non-matching titles rejected, per-event deduplication preferring "Notes by Gemini" (FR-001, FR-002)
+- [x] T005 [P] Write `TestParseDecisionsResponse` table-driven test in `internal/gemini/client_test.go` — verify JSON parsing of decision extraction response: valid array, markdown-wrapped response, empty decisions filtered, invalid category defaults to "open", empty text filtered, empty array (data-model.md parsing rules)
 
 ### Implementation
 
-- [ ] T006 Add decision document collection logic to `SyncCalendarAttachments` in `internal/organizer/organizer.go` — after existing `notesDocIDs` collection (line 288): for each event, check attachment titles for exact "Notes by Gemini" or `strings.HasSuffix(title, "- Transcript")`, apply per-event deduplication, check `--owned-only` via `IsFileOwned`, store in `decisionDocIDs` map (FR-001, FR-002, FR-014, FR-015, R6, R7)
-- [ ] T007 Implement `ExtractDecisions(ctx, transcriptText string) ([]models.Decision, error)` method on `gemini.Client` in `internal/gemini/client.go` — build prompt requesting JSON array with category/text/timestamp/context fields, call `c.client.Models.GenerateContent` with retry, parse response via new `parseDecisionsResponse` helper (FR-006, FR-007, R4)
-- [ ] T008 Implement `parseDecisionsResponse(responseText string) ([]models.Decision, error)` helper in `internal/gemini/client.go` — strip markdown code fences, extract JSON array via regex, unmarshal into `[]Decision`, filter empty text, validate/default category (data-model.md parsing rules)
-- [ ] T009 Run `go test ./internal/organizer/... ./internal/gemini/...` and verify T004, T005 pass. Run `go vet ./...` and `gofmt -l .`
+- [x] T006 Add decision document collection logic to `SyncCalendarAttachments` in `internal/organizer/organizer.go` — after existing `notesDocIDs` collection (line 288): for each event, check attachment titles for exact "Notes by Gemini" or `strings.HasSuffix(title, "- Transcript")`, apply per-event deduplication, check `--owned-only` via `IsFileOwned`, store in `decisionDocIDs` map (FR-001, FR-002, FR-014, FR-015, R6, R7)
+- [x] T007 Implement `ExtractDecisions(ctx, transcriptText string) ([]models.Decision, error)` method on `gemini.Client` in `internal/gemini/client.go` — build prompt requesting JSON array with category/text/timestamp/context fields, call `c.client.Models.GenerateContent` with retry, parse response via new `parseDecisionsResponse` helper (FR-006, FR-007, R4)
+- [x] T008 Implement `parseDecisionsResponse(responseText string) ([]models.Decision, error)` helper in `internal/gemini/client.go` — strip markdown code fences, extract JSON array via regex, unmarshal into `[]Decision`, filter empty text, validate/default category (data-model.md parsing rules)
+- [x] T009 Run `go test ./internal/organizer/... ./internal/gemini/...` and verify T004, T005 pass. Run `go vet ./...` and `gofmt -l .`
 
 **Checkpoint**: Document collection and Gemini decision extraction work independently. Foundation ready for user story implementation.
 
@@ -55,18 +55,18 @@
 
 ### Tests for User Story 1
 
-- [ ] T010 [P] [US1] Write `TestExtractTranscriptContent` table-driven test in `internal/docs/service_test.go` — verify: finds "Transcript" tab in multi-tab doc, uses first tab's content for single-tab doc (via `includeTabsContent=true`), returns empty TranscriptContent for doc with no transcript, extracts full text and H3 heading metadata (FR-003, FR-004)
-- [ ] T011 [P] [US1] Write `TestCreateDecisionsTab` table-driven test in `internal/docs/service_test.go` — verify: creates tab with correct title "Decisions", inserts three H2 section headings, inserts decision bullet text under correct section, handles empty decisions list with "No decisions identified" note (FR-009, FR-010, FR-011, FR-016)
+- [x] T010 [P] [US1] Write `TestExtractTranscriptContent` table-driven test in `internal/docs/service_test.go` — verify: finds "Transcript" tab in multi-tab doc, uses first tab's content for single-tab doc (via `includeTabsContent=true`), returns empty TranscriptContent for doc with no transcript, extracts full text and H3 heading metadata (FR-003, FR-004)
+- [x] T011 [P] [US1] Write `TestCreateDecisionsTab` table-driven test in `internal/docs/service_test.go` — verify: creates tab with correct title "Decisions", inserts three H2 section headings, inserts decision bullet text under correct section, handles empty decisions list with "No decisions identified" note (FR-009, FR-010, FR-011, FR-016)
 
 ### Implementation for User Story 1
 
-- [ ] T012 [US1] Implement `ExtractTranscriptContent(ctx, docID string) (*models.TranscriptContent, error)` in `internal/docs/service.go` — call `Documents.Get(docID)` with `includeTabsContent=true`, always iterate `doc.Tabs` (single-tab docs have one tab entry): find tab with title "Transcript" or use the sole tab for single-tab docs, extract `tab.DocumentTab.Body.Content` text and H3 headings (ParagraphStyle.NamedStyleType == "HEADING_3") with HeadingID/Text/Index (FR-003, FR-004, R2)
-- [ ] T013 [US1] Implement `CreateDecisionsTab(ctx, docID string, decisions []models.Decision, transcript *models.TranscriptContent) error` in `internal/docs/service.go` — BatchUpdate #1: `AddDocumentTab` with title "Decisions", extract TabId from response; BatchUpdate #2: `InsertText` for section headings ("Decisions Made\n", "Decisions Deferred\n", "Open Items\n") and decision bullets, `UpdateParagraphStyle` to style headings as HEADING_2, `CreateParagraphBullets` for decision items; handle empty decisions with "No decisions identified" note (FR-009, FR-010, FR-011, FR-016, R1, R3)
-- [ ] T014 [US1] Add `DocsService` interface to `internal/organizer/organizer.go` with methods: `ExtractTranscriptContent(ctx, docID) (*models.TranscriptContent, error)`, `HasDecisionsTab(ctx, docID) (bool, error)`, `CreateDecisionsTab(ctx, docID, decisions, transcript) error`
-- [ ] T015 [US1] Implement `ExtractDecisionsForDoc(ctx, docID string, docsSvc DocsService, geminiClient *gemini.Client, dryRun bool) error` orchestration function in `internal/organizer/organizer.go` — coordinates: extract transcript → call Gemini → create tab; skip on AI failure with warning (FR-017); log actions for dry-run (FR-013)
-- [ ] T016 [US1] Wire Step 4 into `runCmd.RunE` in `cmd/gcal-organizer/main.go` — after Step 3 block (line ~143) and before `PrintSummary`: get `org.GetDecisionDocIDs()`, iterate, call `initDocsAndGemini` + `ExtractDecisionsForDoc` per doc, aggregate stats, handle dry-run logging
-- [ ] T017 [US1] Add decision stats fields (`DecisionsProcessed`, `DecisionsSkipped`, `DecisionsFailed`) to `Stats` struct and `AddDecisionStats` method in `internal/organizer/organizer.go`; update `PrintSummary` to include decision extraction results
-- [ ] T018 [US1] Run `go test ./...` and verify all tests pass. Run `go build ./...` and `go vet ./...`
+- [x] T012 [US1] Implement `ExtractTranscriptContent(ctx, docID string) (*models.TranscriptContent, error)` in `internal/docs/service.go` — call `Documents.Get(docID)` with `includeTabsContent=true`, always iterate `doc.Tabs` (single-tab docs have one tab entry): find tab with title "Transcript" or use the sole tab for single-tab docs, extract `tab.DocumentTab.Body.Content` text and H3 headings (ParagraphStyle.NamedStyleType == "HEADING_3") with HeadingID/Text/Index (FR-003, FR-004, R2)
+- [x] T013 [US1] Implement `CreateDecisionsTab(ctx, docID string, decisions []models.Decision, transcript *models.TranscriptContent) error` in `internal/docs/service.go` — BatchUpdate #1: `AddDocumentTab` with title "Decisions", extract TabId from response; BatchUpdate #2: `InsertText` for section headings ("Decisions Made\n", "Decisions Deferred\n", "Open Items\n") and decision bullets, `UpdateParagraphStyle` to style headings as HEADING_2, `CreateParagraphBullets` for decision items; handle empty decisions with "No decisions identified" note (FR-009, FR-010, FR-011, FR-016, R1, R3)
+- [x] T014 [US1] Add `DocsService` interface to `internal/organizer/organizer.go` with methods: `ExtractTranscriptContent(ctx, docID) (*models.TranscriptContent, error)`, `HasDecisionsTab(ctx, docID) (bool, error)`, `CreateDecisionsTab(ctx, docID, decisions, transcript) error`
+- [x] T015 [US1] Implement `ExtractDecisionsForDoc(ctx, docID string, docsSvc DocsService, geminiClient *gemini.Client, dryRun bool) error` orchestration function in `internal/organizer/organizer.go` — coordinates: extract transcript → call Gemini → create tab; skip on AI failure with warning (FR-017); log actions for dry-run (FR-013)
+- [x] T016 [US1] Wire Step 4 into `runCmd.RunE` in `cmd/gcal-organizer/main.go` — after Step 3 block (line ~143) and before `PrintSummary`: get `org.GetDecisionDocIDs()`, iterate, call `initDocsAndGemini` + `ExtractDecisionsForDoc` per doc, aggregate stats, handle dry-run logging
+- [x] T017 [US1] Add decision stats fields (`DecisionsProcessed`, `DecisionsSkipped`, `DecisionsFailed`) to `Stats` struct and `AddDecisionStats` method in `internal/organizer/organizer.go`; update `PrintSummary` to include decision extraction results
+- [x] T018 [US1] Run `go test ./...` and verify all tests pass. Run `go build ./...` and `go vet ./...`
 
 **Checkpoint**: Decision extraction is fully functional. Documents get a "Decisions" tab with categorized decisions (without cross-tab links yet). MVP complete.
 
@@ -80,14 +80,14 @@
 
 ### Tests for User Story 2
 
-- [ ] T019 [P] [US2] Write `TestTimestampToHeadingMatch` table-driven test in `internal/docs/service_test.go` — verify: exact timestamp match returns correct HeadingID, nearest preceding heading found when no exact match, no headings returns nil, multiple headings with same prefix handled correctly (FR-008, data-model.md timestamp matching rules)
-- [ ] T020 [P] [US2] Write `TestCreateDecisionsTabWithLinks` test in `internal/docs/service_test.go` — verify: `UpdateTextStyle` requests include `Link.Heading` with correct `HeadingLink{Id, TabId}` for each decision with a matched timestamp; decisions without matched timestamps have no link applied (FR-012)
+- [x] T019 [P] [US2] Write `TestTimestampToHeadingMatch` table-driven test in `internal/docs/service_test.go` — verify: exact timestamp match returns correct HeadingID, nearest preceding heading found when no exact match, no headings returns nil, multiple headings with same prefix handled correctly (FR-008, data-model.md timestamp matching rules)
+- [x] T020 [P] [US2] Write `TestCreateDecisionsTabWithLinks` test in `internal/docs/service_test.go` — verify: `UpdateTextStyle` requests include `Link.Heading` with correct `HeadingLink{Id, TabId}` for each decision with a matched timestamp; decisions without matched timestamps have no link applied (FR-012)
 
 ### Implementation for User Story 2
 
-- [ ] T021 [US2] Implement `matchTimestampToHeading(timestamp string, headings []models.TranscriptHeading) *models.TranscriptHeading` helper in `internal/docs/service.go` — find heading whose text contains the decision's timestamp; if no exact match, find nearest preceding by document position; return nil if no headings (FR-008, data-model.md timestamp matching)
-- [ ] T022 [US2] Extend `CreateDecisionsTab` in `internal/docs/service.go` to add cross-tab heading links — in BatchUpdate #2: for each decision with a matched timestamp heading, add `UpdateTextStyleRequest` with `TextStyle.Link.Heading = &HeadingLink{Id: heading.HeadingID, TabId: transcript.TabID}` targeting the timestamp text range within the decision bullet (FR-012, R2)
-- [ ] T023 [US2] Run `go test ./internal/docs/...` and verify T019, T020 pass alongside existing tests
+- [x] T021 [US2] Implement `matchTimestampToHeading(timestamp string, headings []models.TranscriptHeading) *models.TranscriptHeading` helper in `internal/docs/service.go` — find heading whose text contains the decision's timestamp; if no exact match, find nearest preceding by document position; return nil if no headings (FR-008, data-model.md timestamp matching)
+- [x] T022 [US2] Extend `CreateDecisionsTab` in `internal/docs/service.go` to add cross-tab heading links — in BatchUpdate #2: for each decision with a matched timestamp heading, add `UpdateTextStyleRequest` with `TextStyle.Link.Heading = &HeadingLink{Id: heading.HeadingID, TabId: transcript.TabID}` targeting the timestamp text range within the decision bullet (FR-012, R2)
+- [x] T023 [US2] Run `go test ./internal/docs/...` and verify T019, T020 pass alongside existing tests
 
 **Checkpoint**: Decisions now have clickable cross-tab timestamp links. US1 + US2 both work independently.
 
@@ -101,15 +101,15 @@
 
 ### Tests for User Story 3
 
-- [ ] T024 [P] [US3] Write `TestHasDecisionsTab` table-driven test in `internal/docs/service_test.go` — verify: returns true when "Decisions" tab exists, returns false when no "Decisions" tab, returns true for manually-created "Decisions" tab (FR-005)
-- [ ] T025 [P] [US3] Write `TestOptimisticConcurrency` test in `internal/docs/service_test.go` — verify: when `AddDocumentTab` returns an error indicating duplicate tab, `CreateDecisionsTab` returns a sentinel error that the caller treats as "already processed" (FR-018, R5)
+- [x] T024 [P] [US3] Write `TestHasDecisionsTab` table-driven test in `internal/docs/service_test.go` — verify: returns true when "Decisions" tab exists, returns false when no "Decisions" tab, returns true for manually-created "Decisions" tab (FR-005)
+- [x] T025 [P] [US3] Write `TestOptimisticConcurrency` test in `internal/docs/service_test.go` — verify: when `AddDocumentTab` returns an error indicating duplicate tab, `CreateDecisionsTab` returns a sentinel error that the caller treats as "already processed" (FR-018, R5)
 
 ### Implementation for User Story 3
 
-- [ ] T026 [US3] Implement `HasDecisionsTab(ctx, docID string) (bool, error)` in `internal/docs/service.go` — call `GetDocument`, iterate `doc.Tabs` checking for `tab.TabProperties.Title == "Decisions"`, return true/false (FR-005, R5)
-- [ ] T027 [US3] Add idempotency check to `ExtractDecisionsForDoc` in `internal/organizer/organizer.go` — call `docsSvc.HasDecisionsTab` before processing; if true, log "already processed" and increment `DecisionsSkipped` stat; return early (FR-005)
-- [ ] T028 [US3] Add optimistic concurrency handling to `CreateDecisionsTab` in `internal/docs/service.go` — if `AddDocumentTab` BatchUpdate returns an error, check if error indicates duplicate tab name; if so, return `ErrDecisionsTabExists` sentinel; caller in `ExtractDecisionsForDoc` catches this and treats as "already processed" (FR-018, R5)
-- [ ] T029 [US3] Run `go test ./...` and verify all tests pass including idempotency scenarios
+- [x] T026 [US3] Implement `HasDecisionsTab(ctx, docID string) (bool, error)` in `internal/docs/service.go` — call `GetDocument`, iterate `doc.Tabs` checking for `tab.TabProperties.Title == "Decisions"`, return true/false (FR-005, R5)
+- [x] T027 [US3] Add idempotency check to `ExtractDecisionsForDoc` in `internal/organizer/organizer.go` — call `docsSvc.HasDecisionsTab` before processing; if true, log "already processed" and increment `DecisionsSkipped` stat; return early (FR-005)
+- [x] T028 [US3] Add optimistic concurrency handling to `CreateDecisionsTab` in `internal/docs/service.go` — if `AddDocumentTab` BatchUpdate returns an error, check if error indicates duplicate tab name; if so, return `ErrDecisionsTabExists` sentinel; caller in `ExtractDecisionsForDoc` catches this and treats as "already processed" (FR-018, R5)
+- [x] T029 [US3] Run `go test ./...` and verify all tests pass including idempotency scenarios
 
 **Checkpoint**: Idempotent and concurrency-safe. Multiple runs produce zero duplicates (SC-004).
 
@@ -123,9 +123,9 @@
 
 ### Implementation for User Story 4
 
-- [ ] T030 [US4] Add dry-run guard to `ExtractDecisionsForDoc` in `internal/organizer/organizer.go` — when `dryRun` is true: skip Gemini and all BatchUpdate calls; only log eligible document title and transcript size (e.g., "Would extract decisions from [doc title] (N characters)"); consistent with Step 3's dry-run pattern which skips expensive operations (FR-013)
-- [ ] T031 [US4] Verify `--owned-only` filtering in `SyncCalendarAttachments` decision collection (from T006) — ensure `IsFileOwned` check gates entry into `decisionDocIDs` map when `o.config.OwnedOnly` is true (FR-014); already implemented in T006 but verify with manual test
-- [ ] T032 [US4] Add dry-run and owned-only output formatting in Step 4 block of `cmd/gcal-organizer/main.go` — match existing Step 3 patterns: "Would extract decisions from N documents" for dry-run, "No owned transcript documents found" when `--owned-only` filters all docs
+- [x] T030 [US4] Add dry-run guard to `ExtractDecisionsForDoc` in `internal/organizer/organizer.go` — when `dryRun` is true: skip Gemini and all BatchUpdate calls; only log eligible document title and transcript size (e.g., "Would extract decisions from [doc title] (N characters)"); consistent with Step 3's dry-run pattern which skips expensive operations (FR-013)
+- [x] T031 [US4] Verify `--owned-only` filtering in `SyncCalendarAttachments` decision collection (from T006) — ensure `IsFileOwned` check gates entry into `decisionDocIDs` map when `o.config.OwnedOnly` is true (FR-014); already implemented in T006 but verify with manual test
+- [x] T032 [US4] Add dry-run and owned-only output formatting in Step 4 block of `cmd/gcal-organizer/main.go` — match existing Step 3 patterns: "Would extract decisions from N documents" for dry-run, "No owned transcript documents found" when `--owned-only` filters all docs
 
 **Checkpoint**: All four user stories complete. Full feature ready for polish.
 
@@ -135,10 +135,10 @@
 
 **Purpose**: Documentation, cleanup, and validation across all stories
 
-- [ ] T033 [P] Update README.md with Step 4 documentation — describe decision extraction behavior, supported document patterns, example output
-- [ ] T034 [P] Update AGENTS.md project structure if needed — verify `internal/docs/` description reflects write capability
-- [ ] T035 [P] Update `man/gcal-organizer.1` man page with Step 4 behavior — add decision extraction description to the workflow section, per constitution documentation requirement
-- [ ] T036 Run `make ci` — verify no regressions and all quality gates pass (SC-006, constitution Quality Gates)
+- [x] T033 [P] Update README.md with Step 4 documentation — describe decision extraction behavior, supported document patterns, example output
+- [x] T034 [P] Update AGENTS.md project structure if needed — verify `internal/docs/` description reflects write capability
+- [x] T035 [P] Update `man/gcal-organizer.1` man page with Step 4 behavior — add decision extraction description to the workflow section, per constitution documentation requirement
+- [x] T036 Run `make ci` — verify no regressions and all quality gates pass (SC-006, constitution Quality Gates)
 - [ ] T037 Run `gcal-organizer run --dry-run` against a real calendar with transcript attachments — manual validation of end-to-end flow
 - [ ] T038 Verify quickstart.md scenarios work as documented in `specs/008-decision-extraction/quickstart.md`
 


### PR DESCRIPTION
## Summary

- **008 Decision Extraction**: Full implementation of meeting transcript decision extraction — Gemini-powered analysis creates a categorized "Decisions" tab in Google Docs with cross-tab timestamp links to the transcript
- **007 Secure Credential Storage wiring**: Wire the existing `internal/secrets` SecretStore into auth, config, and all CLI commands — OAuth tokens and API keys now stored in OS keychain (macOS Keychain / Linux Secret Service) by default, with `--no-keyring` fallback for headless environments
- **Review Council remediation**: Fix all HIGH/MEDIUM/LOW findings from 3 iterations of `/review-council` (Adversary, Architect, Guard)

## Key Changes

### Feature 008 — Decision Extraction
- Add `Decision`, `TranscriptContent`, `TranscriptHeading` models
- Implement Gemini transcript analysis with structured JSON extraction
- Create "Decisions" tab via Google Docs BatchUpdate with heading styles, bullets, and cross-tab heading links
- UTF-16 index calculation for correct non-ASCII formatting
- Full test coverage for content building, timestamp matching, and transcript extraction

### Feature 007 — SecretStore Wiring (Phases 3-8)
- Refactor `OAuthClient` to accept `SecretStore` with `persistingTokenSource` for automatic refresh persistence
- Add `NoKeyring` config field, `LoadSecrets()` method, `--no-keyring` flag, `GCAL_NO_KEYRING` env var
- `loadConfigAndStore()` helper eliminates redundant keychain probes
- `auth login` persists credentials to store; `config show` / `auth status` report backend
- `doctor` checks keychain for tokens (not just `token.json`)

### Security & Resilience Fixes
- Nil pointer guard on Gemini safety-filtered responses
- Remove sensitive task text from error messages
- Signal-based context cancellation (SIGINT/SIGTERM) on all commands
- `mustBindEnv` / `mustBindPFlag` surface config binding errors at startup
- POSIX env key validation in `.env` parser
- Structured `googleapi.Error` matching instead of fragile string matching

### Zero-Waste Cleanup
- Remove dead `IsClaimed`/`ClaimEmoji`/`ClaimTTL`/`isClaimActive()` code
- Remove phantom `internal/tasks/` from README and reviewer agent
- Fix AGENTS.md `scripts/` → `browser/`
- Update all spec statuses to reflect actual implementation state
- Fix Gemini model docs mismatch (`gemini-1.5-flash` → `gemini-2.0-flash`)

## Review Council Verdict

**APPROVE** — all three reviewers (Adversary, Architect, Guard) approved after 3 iterations.

## Known Tracked Gaps

- Phase 6 migration (`migrate.go`): Existing users may need `auth login` after upgrade. Tracked in `specs/007/tasks.md` T029–T035.
- Phase 8 polish (T045, T047, T048): Remaining doc/CI tasks for 007.