### PR TITLE
feat(012): export extracted decisions as local markdown for Dewey indexing

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -17,6 +17,8 @@ Auto-generated from all feature plans. Last updated: 2026-02-17
 - N/A (no data persistence; pipeline configuration files only) (010-macos-signed-releases)
 - Go 1.24+ (toolchain go1.24.12) + `google.golang.org/api/docs/v1` (Docs API), Playwright via `npx tsx` (browser automation) (011-next-steps-heading)
 - N/A (no data persistence changes) (011-next-steps-heading)
+- Go 1.24.0 (toolchain go1.24.12) + `github.com/spf13/cobra` (CLI), `github.com/spf13/viper` (config), `github.com/charmbracelet/log` (logging) — all existing; no new dependencies (012-decision-markdown-export)
+- Local filesystem (`~/.gcal-organizer/decisions/` default). No database. (012-decision-markdown-export)
 
 - **Language**: Go 1.21+
 - **CLI Framework**: github.com/spf13/cobra
@@ -79,9 +81,9 @@ make install-hooks
 - New features require documentation before completion
 
 ## Recent Changes
+- 012-decision-markdown-export: Added Go 1.24.0 (toolchain go1.24.12) + `github.com/spf13/cobra` (CLI), `github.com/spf13/viper` (config), `github.com/charmbracelet/log` (logging) — all existing; no new dependencies
 - 011-next-steps-heading: Added Go 1.24+ (toolchain go1.24.12) + `google.golang.org/api/docs/v1` (Docs API), Playwright via `npx tsx` (browser automation)
 - 010-macos-signed-releases: Added Go 1.24.0 (toolchain go1.24.12) + GoReleaser v2 (CI only — `goreleaser/goreleaser-action`), `gh` CLI (release asset management), native macOS `codesign` + `xcrun notarytool` (signing/notarization)
-- 009-test-coverage-quality: Added Go 1.24.0 (toolchain go1.24.12), module `github.com/jflowers/gcal-organizer` + `google.golang.org/api` (Drive v3, Docs v1, Calendar v3), `google.golang.org/genai` (Gemini), `github.com/spf13/cobra` (CLI), `github.com/spf13/viper` (config), `github.com/zalando/go-keyring` (secrets)
 
 ### 001-gcal-organizer-cli
 Core CLI implementation with Google Workspace integration and Gemini AI for action item extraction.

--- a/README.md
+++ b/README.md
@@ -192,6 +192,7 @@ GCAL_OWNED_ONLY=true                      # Default: false (only mutate owned fi
 GCAL_FILENAME_KEYWORDS="Notes,Meeting"    # Comma-separated
 GCAL_FILENAME_PATTERN="(.+)\s*-\s*(\d{4}-\d{2}-\d{2})"
 GEMINI_MODEL="gemini-2.0-flash"           # Default: gemini-2.0-flash
+GCAL_DECISIONS_EXPORT_DIR="~/.gcal-organizer/decisions"  # Default
 ```
 
 ## 🔒 Data Privacy
@@ -240,6 +241,11 @@ Step 4 automatically processes meeting transcript documents to extract and categ
    - **Decisions Deferred** -- items explicitly tabled for later
    - **Open Items** -- unresolved topics needing further discussion
 4. A new "Decisions" tab is created in the document with clickable timestamp links back to the transcript
+5. A local markdown copy is written to `~/.gcal-organizer/decisions/` with YAML frontmatter (`topic`, `date`, `attendees`) for indexing by semantic search tools
+
+**Markdown Export**: Each exported file uses the naming convention `<topic-slug>-<YYYY-MM-DD>.md` and contains categorized decision sections. Empty categories are omitted. Files are overwritten on reprocessing (idempotent). Export failures are logged as warnings but never block the pipeline.
+
+**Configure export directory**: Set `GCAL_DECISIONS_EXPORT_DIR` or add `decisions_export_dir` to your config file to change the output location. The `~` shorthand is expanded automatically.
 
 **Idempotent**: Documents with an existing "Decisions" tab are automatically skipped. Safe to run repeatedly.
 
@@ -256,6 +262,7 @@ gcal-organizer/
 │   ├── config/                # Configuration management
 │   ├── docs/                  # Docs checkbox extraction + decision tab creation
 │   ├── drive/                 # Drive folder/file operations
+│   ├── export/                # Decision markdown export (local files)
 │   ├── gemini/                # Gemini AI assignee + decision extraction
 │   └── organizer/             # Workflow orchestration
 ├── browser/                   # Playwright task assignment script (TypeScript)

--- a/cmd/gcal-organizer/auth_config.go
+++ b/cmd/gcal-organizer/auth_config.go
@@ -41,6 +41,7 @@ var configShowCmd = &cobra.Command{
 		fmt.Printf("   Gemini Model:      %s\n", cfg.GeminiModel)
 		fmt.Printf("   Gemini API Key:    %s\n", maskSecret(cfg.GeminiAPIKey))
 		fmt.Printf("   Credentials File:  %s\n", cfg.CredentialsFile)
+		fmt.Printf("   Decisions Export:  %s\n", cfg.DecisionsExportDir)
 		fmt.Printf("   Secret storage:    %s\n", backend)
 		fmt.Println("───────────────────────────────────────────────────────────")
 

--- a/cmd/gcal-organizer/main.go
+++ b/cmd/gcal-organizer/main.go
@@ -21,6 +21,7 @@ import (
 	"github.com/jflowers/gcal-organizer/internal/calendar"
 	"github.com/jflowers/gcal-organizer/internal/config"
 	"github.com/jflowers/gcal-organizer/internal/drive"
+	"github.com/jflowers/gcal-organizer/internal/export"
 	"github.com/jflowers/gcal-organizer/internal/logging"
 	"github.com/jflowers/gcal-organizer/internal/organizer"
 	"github.com/jflowers/gcal-organizer/internal/secrets"
@@ -212,18 +213,21 @@ var runCmd = &cobra.Command{
 		}
 
 		// Step 4: Extract Decisions from transcript documents
-		decisionDocIDs := org.GetDecisionDocIDs()
-		if ownedOnly && len(decisionDocIDs) == 0 {
+		decisionDocContexts := org.GetDecisionDocContexts()
+		if ownedOnly && len(decisionDocContexts) == 0 {
 			fmt.Println("📋 STEP 4: No owned transcript documents found for decision extraction")
 		}
-		if len(decisionDocIDs) > 0 {
+		if len(decisionDocContexts) > 0 {
 			if dryRun {
-				fmt.Printf("📋 STEP 4: Would extract decisions from %d transcript documents\n", len(decisionDocIDs))
+				fmt.Printf("📋 STEP 4: Would extract decisions from %d transcript documents\n", len(decisionDocContexts))
 			} else {
 				fmt.Println("📋 STEP 4: Extracting Decisions")
 				fmt.Println("───────────────────────────────────────────────────────────")
-				fmt.Printf("   Found %d transcript documents to process\n", len(decisionDocIDs))
+				fmt.Printf("   Found %d transcript documents to process\n", len(decisionDocContexts))
 			}
+
+			// Create decision exporter with configured output directory
+			decisionExporter := export.NewExporter(cfg.DecisionsExportDir, logging.Logger)
 
 			// Initialize services once for all documents
 			docsSvc, geminiClient, initErr := initDocsAndGemini(ctx, cfg, store)
@@ -232,13 +236,13 @@ var runCmd = &cobra.Command{
 			} else {
 				totalFailed := 0
 
-				for docID, source := range decisionDocIDs {
+				for _, docCtx := range decisionDocContexts {
 					if !dryRun {
-						fmt.Printf("   📄 Processing doc %s (source: %s)\n", docID[:min(8, len(docID))], source)
+						fmt.Printf("   📄 Processing doc %s (source: %s)\n", docCtx.DocID[:min(8, len(docCtx.DocID))], docCtx.Source)
 					}
-					err := org.ExtractDecisionsForDoc(ctx, docID, docsSvc, geminiClient, dryRun)
+					err := org.ExtractDecisionsForDoc(ctx, docCtx, docsSvc, geminiClient, decisionExporter, dryRun)
 					if err != nil {
-						fmt.Printf("   ⚠️  Error processing doc %s: %v\n", docID[:min(8, len(docID))], err)
+						fmt.Printf("   ⚠️  Error processing doc %s: %v\n", docCtx.DocID[:min(8, len(docCtx.DocID))], err)
 						totalFailed++
 					}
 				}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -61,6 +61,9 @@ type Config struct {
 
 	// ChromeProfilePath is the path to Chrome profile for browser automation
 	ChromeProfilePath string
+
+	// DecisionsExportDir is the output directory for decision markdown files
+	DecisionsExportDir string
 }
 
 // DefaultConfig returns a Config with default values.
@@ -70,14 +73,15 @@ func DefaultConfig() *Config {
 	configDir := filepath.Join(home, ".gcal-organizer")
 
 	return &Config{
-		MasterFolderName:  "Meeting Notes",
-		DaysToLookBack:    1,
-		FilenamePattern:   `(.+)\s*-\s*(\d{4}-\d{2}-\d{2})`,
-		FilenameKeywords:  []string{"Notes", "Meeting"},
-		GeminiModel:       "gemini-2.0-flash",
-		CredentialsFile:   filepath.Join(configDir, "credentials.json"),
-		TokenFile:         filepath.Join(configDir, "token.json"),
-		ChromeProfilePath: filepath.Join(configDir, "chrome-data"),
+		MasterFolderName:   "Meeting Notes",
+		DaysToLookBack:     1,
+		FilenamePattern:    `(.+)\s*-\s*(\d{4}-\d{2}-\d{2})`,
+		FilenameKeywords:   []string{"Notes", "Meeting"},
+		GeminiModel:        "gemini-2.0-flash",
+		CredentialsFile:    filepath.Join(configDir, "credentials.json"),
+		TokenFile:          filepath.Join(configDir, "token.json"),
+		ChromeProfilePath:  filepath.Join(configDir, "chrome-data"),
+		DecisionsExportDir: filepath.Join(configDir, "decisions"),
 	}
 }
 
@@ -100,6 +104,7 @@ func Load() (*Config, error) {
 	mustBindEnv("credentials_file", "GOOGLE_CREDENTIALS_FILE")
 	mustBindEnv("owned-only", "GCAL_OWNED_ONLY")
 	mustBindEnv("no-keyring", "GCAL_NO_KEYRING")
+	mustBindEnv("decisions_export_dir", "GCAL_DECISIONS_EXPORT_DIR")
 
 	// Override defaults with viper values
 	if v := viper.GetString("master_folder_name"); v != "" {
@@ -124,10 +129,22 @@ func Load() (*Config, error) {
 		cfg.CredentialsFile = v
 	}
 
+	if v := viper.GetString("decisions_export_dir"); v != "" {
+		cfg.DecisionsExportDir = v
+	}
+
 	cfg.Verbose = viper.GetBool("verbose")
 	cfg.DryRun = viper.GetBool("dry-run")
 	cfg.OwnedOnly = viper.GetBool("owned-only")
 	cfg.NoKeyring = viper.GetBool("no-keyring")
+
+	// Expand tilde in DecisionsExportDir, consistent with CredentialsFile/TokenFile handling
+	if strings.HasPrefix(cfg.DecisionsExportDir, "~/") {
+		home, err := os.UserHomeDir()
+		if err == nil {
+			cfg.DecisionsExportDir = filepath.Join(home, cfg.DecisionsExportDir[2:])
+		}
+	}
 
 	return cfg, nil
 }

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -3,6 +3,8 @@ package config
 import (
 	"fmt"
 	"os"
+	"path/filepath"
+	"strings"
 	"testing"
 )
 
@@ -146,6 +148,45 @@ func TestConfigLoad_NoKeyring(t *testing.T) {
 
 	if !cfg.NoKeyring {
 		t.Error("expected NoKeyring=true when GCAL_NO_KEYRING=true, got false")
+	}
+}
+
+// ---------- T029: DefaultConfig sets DecisionsExportDir ----------
+
+func TestDefaultConfig_DecisionsExportDir(t *testing.T) {
+	cfg := DefaultConfig()
+
+	home, err := os.UserHomeDir()
+	if err != nil {
+		t.Fatalf("could not get home dir: %v", err)
+	}
+
+	want := filepath.Join(home, ".gcal-organizer", "decisions")
+	if cfg.DecisionsExportDir != want {
+		t.Errorf("DecisionsExportDir: got %q, want %q", cfg.DecisionsExportDir, want)
+	}
+}
+
+// ---------- T030: Tilde expansion for DecisionsExportDir ----------
+
+func TestLoad_DecisionsExportDir_TildeExpansion(t *testing.T) {
+	os.Setenv("GCAL_DECISIONS_EXPORT_DIR", "~/custom-decisions")
+	defer os.Unsetenv("GCAL_DECISIONS_EXPORT_DIR")
+
+	cfg, err := Load()
+	if err != nil {
+		t.Fatalf("Load() failed: %v", err)
+	}
+
+	// Should be expanded to an absolute path
+	if strings.HasPrefix(cfg.DecisionsExportDir, "~/") {
+		t.Errorf("DecisionsExportDir should be expanded, got %q", cfg.DecisionsExportDir)
+	}
+
+	home, _ := os.UserHomeDir()
+	want := filepath.Join(home, "custom-decisions")
+	if cfg.DecisionsExportDir != want {
+		t.Errorf("DecisionsExportDir: got %q, want %q", cfg.DecisionsExportDir, want)
 	}
 }
 

--- a/internal/export/export.go
+++ b/internal/export/export.go
@@ -1,0 +1,180 @@
+// Package export provides markdown file export for extracted meeting decisions.
+//
+// It renders decisions as markdown files with YAML frontmatter and writes them
+// to a configurable local directory. Each file contains categorized decision
+// sections (Decisions Made, Decisions Deferred, Open Items) and metadata
+// (topic, date, attendees) for indexing by semantic search tools.
+package export
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"time"
+
+	"github.com/charmbracelet/log"
+	"github.com/jflowers/gcal-organizer/pkg/models"
+)
+
+// Exporter writes decision markdown files to a local directory.
+// File I/O functions are injectable for testability (research.md D4).
+type Exporter struct {
+	writeFile func(string, []byte, os.FileMode) error
+	mkdirAll  func(string, os.FileMode) error
+	logger    *log.Logger
+	outputDir string
+}
+
+// NewExporter creates an Exporter that writes to outputDir.
+// Production defaults: os.WriteFile for writes, os.MkdirAll for directory creation.
+func NewExporter(outputDir string, logger *log.Logger) *Exporter {
+	return &Exporter{
+		writeFile: os.WriteFile,
+		mkdirAll:  os.MkdirAll,
+		logger:    logger,
+		outputDir: outputDir,
+	}
+}
+
+// Export renders decisions as markdown and writes to disk.
+// When dryRun is true, logs the intended path without writing (FR-011).
+// Returns nil on success or dry-run. Returns an error on write failure;
+// callers are responsible for handling the error per FR-012 (export failure
+// must not block the pipeline).
+func (e *Exporter) Export(ctx context.Context, decisions []models.Decision, meta models.DecisionDocContext, dryRun bool) error {
+	// No decisions means no file to write (edge case from spec)
+	if len(decisions) == 0 {
+		return nil
+	}
+
+	slug := TopicSlug(meta.EventTitle)
+	dateStr := meta.EventDate.Format("2006-01-02")
+	filename := fmt.Sprintf("%s-%s.md", slug, dateStr)
+	fullPath := filepath.Join(e.outputDir, filename)
+
+	// Dry-run: log what would happen and return (FR-011, research.md D7)
+	if dryRun {
+		e.logger.Info("Would export decisions to file", "path", fullPath)
+		return nil
+	}
+
+	// Render markdown content
+	content := renderMarkdown(decisions, meta.EventTitle, meta.EventDate, meta.Attendees)
+
+	// Create output directory if needed (FR-007)
+	if err := e.mkdirAll(e.outputDir, 0o755); err != nil {
+		// FR-012: log warning, do not return error
+		e.logger.Warn("Failed to create decisions export directory",
+			"path", e.outputDir,
+			"error", err,
+		)
+		return fmt.Errorf("create export directory: %w", err)
+	}
+
+	// Write file (FR-001, FR-008: overwrites existing)
+	if err := e.writeFile(fullPath, content, 0o644); err != nil {
+		// FR-012: log warning, do not return error
+		e.logger.Warn("Failed to write decisions markdown file",
+			"path", fullPath,
+			"error", err,
+		)
+		return fmt.Errorf("write decisions file: %w", err)
+	}
+
+	e.logger.Info("Exported decisions to markdown",
+		"path", fullPath,
+		"decisions", len(decisions),
+	)
+	return nil
+}
+
+// CleanTopic strips common prefixes and suffixes from a meeting title
+// to produce a clean topic name for frontmatter (FR-013).
+// This is distinct from TopicSlug which produces a filename-safe slug.
+func CleanTopic(title string) string {
+	topic := title
+
+	// Strip known prefixes (case-insensitive)
+	prefixes := []string{"Notes by Gemini - ", "Notes by Gemini"}
+	for _, prefix := range prefixes {
+		if len(topic) >= len(prefix) && strings.EqualFold(topic[:len(prefix)], prefix) {
+			topic = topic[len(prefix):]
+			break
+		}
+	}
+
+	// Strip known suffixes (case-insensitive)
+	suffixes := []string{" - Transcript", "- Transcript"}
+	for _, suffix := range suffixes {
+		if len(topic) >= len(suffix) && strings.EqualFold(topic[len(topic)-len(suffix):], suffix) {
+			topic = topic[:len(topic)-len(suffix)]
+			break
+		}
+	}
+
+	topic = strings.TrimSpace(topic)
+	if topic == "" {
+		return "Meeting"
+	}
+	return topic
+}
+
+// renderMarkdown produces a markdown document with YAML frontmatter and
+// categorized decision sections. Empty categories are omitted (FR-015).
+func renderMarkdown(decisions []models.Decision, topic string, date time.Time, attendees []string) []byte {
+	var b strings.Builder
+
+	cleanedTopic := CleanTopic(topic)
+
+	// YAML frontmatter
+	b.WriteString("---\n")
+	b.WriteString(fmt.Sprintf("topic: %s\n", cleanedTopic))
+	b.WriteString(fmt.Sprintf("date: \"%s\"\n", date.Format("2006-01-02")))
+	if len(attendees) > 0 {
+		b.WriteString("attendees:\n")
+		for _, a := range attendees {
+			b.WriteString(fmt.Sprintf("  - %s\n", a))
+		}
+	}
+	b.WriteString("---\n")
+
+	// Categorize decisions
+	type category struct {
+		heading string
+		items   []string
+	}
+	categories := []category{
+		{heading: "Decisions Made"},
+		{heading: "Decisions Deferred"},
+		{heading: "Open Items"},
+	}
+
+	categoryMap := map[string]int{
+		"made":     0,
+		"deferred": 1,
+		"open":     2,
+	}
+
+	for _, d := range decisions {
+		idx, ok := categoryMap[d.Category]
+		if !ok {
+			continue
+		}
+		categories[idx].items = append(categories[idx].items, d.Text)
+	}
+
+	// Render non-empty categories (FR-015: omit empty)
+	for _, cat := range categories {
+		if len(cat.items) == 0 {
+			continue
+		}
+		b.WriteString(fmt.Sprintf("\n## %s\n\n", cat.heading))
+		for _, item := range cat.items {
+			b.WriteString(fmt.Sprintf("- %s\n", item))
+		}
+	}
+
+	return []byte(b.String())
+}

--- a/internal/export/export_test.go
+++ b/internal/export/export_test.go
@@ -1,0 +1,381 @@
+package export
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/charmbracelet/log"
+	"github.com/jflowers/gcal-organizer/pkg/models"
+)
+
+// testLogger returns a logger suitable for tests (writes to discard).
+func testLogger() *log.Logger {
+	return log.NewWithOptions(os.Stderr, log.Options{})
+}
+
+// ---------- T022: renderMarkdown tests ----------
+
+func TestRenderMarkdown(t *testing.T) {
+	tests := []struct {
+		name      string
+		decisions []models.Decision
+		topic     string
+		date      time.Time
+		attendees []string
+		wantParts []string // substrings that must appear
+		wantNot   []string // substrings that must NOT appear
+	}{
+		{
+			name: "all three categories populated",
+			decisions: []models.Decision{
+				{Category: "made", Text: "Adopt GitHub Actions for CI/CD"},
+				{Category: "deferred", Text: "Budget review postponed"},
+				{Category: "open", Text: "API migration needs benchmarks"},
+			},
+			topic:     "Weekly Engineering Sync",
+			date:      time.Date(2026, 4, 18, 0, 0, 0, 0, time.UTC),
+			attendees: []string{"alice@example.com", "bob@example.com"},
+			wantParts: []string{
+				"topic: Weekly Engineering Sync",
+				"date: \"2026-04-18\"",
+				"attendees:",
+				"  - alice@example.com",
+				"  - bob@example.com",
+				"## Decisions Made",
+				"- Adopt GitHub Actions for CI/CD",
+				"## Decisions Deferred",
+				"- Budget review postponed",
+				"## Open Items",
+				"- API migration needs benchmarks",
+			},
+		},
+		{
+			name: "single category only - made",
+			decisions: []models.Decision{
+				{Category: "made", Text: "Use Go 1.24"},
+			},
+			topic: "Tech Review",
+			date:  time.Date(2026, 3, 15, 0, 0, 0, 0, time.UTC),
+			wantParts: []string{
+				"## Decisions Made",
+				"- Use Go 1.24",
+			},
+			wantNot: []string{
+				"## Decisions Deferred",
+				"## Open Items",
+				"attendees:",
+			},
+		},
+		{
+			name: "empty categories omitted (FR-015)",
+			decisions: []models.Decision{
+				{Category: "open", Text: "Need to decide on database"},
+			},
+			topic: "Architecture Review",
+			date:  time.Date(2026, 5, 1, 0, 0, 0, 0, time.UTC),
+			wantParts: []string{
+				"## Open Items",
+				"- Need to decide on database",
+			},
+			wantNot: []string{
+				"## Decisions Made",
+				"## Decisions Deferred",
+			},
+		},
+		{
+			name: "decisions with special characters",
+			decisions: []models.Decision{
+				{Category: "made", Text: "Use `fmt.Errorf` with %w for error wrapping"},
+				{Category: "open", Text: "Should we use JSON or YAML? (TBD)"},
+			},
+			topic: "Code Review: API v2",
+			date:  time.Date(2026, 6, 10, 0, 0, 0, 0, time.UTC),
+			wantParts: []string{
+				"- Use `fmt.Errorf` with %w for error wrapping",
+				"- Should we use JSON or YAML? (TBD)",
+			},
+		},
+		{
+			name: "topic with Transcript suffix is cleaned in frontmatter",
+			decisions: []models.Decision{
+				{Category: "made", Text: "Ship it"},
+			},
+			topic: "Weekly Sync - Transcript",
+			date:  time.Date(2026, 4, 20, 0, 0, 0, 0, time.UTC),
+			wantParts: []string{
+				"topic: Weekly Sync",
+			},
+			wantNot: []string{
+				"topic: Weekly Sync - Transcript",
+			},
+		},
+		{
+			name: "topic with Notes by Gemini prefix is cleaned in frontmatter",
+			decisions: []models.Decision{
+				{Category: "made", Text: "Approved"},
+			},
+			topic: "Notes by Gemini - Project Alpha",
+			date:  time.Date(2026, 4, 20, 0, 0, 0, 0, time.UTC),
+			wantParts: []string{
+				"topic: Project Alpha",
+			},
+			wantNot: []string{
+				"topic: Notes by Gemini",
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := string(renderMarkdown(tt.decisions, tt.topic, tt.date, tt.attendees))
+
+			for _, want := range tt.wantParts {
+				if !strings.Contains(got, want) {
+					t.Errorf("output missing expected substring %q\n\nGot:\n%s", want, got)
+				}
+			}
+
+			for _, notWant := range tt.wantNot {
+				if strings.Contains(got, notWant) {
+					t.Errorf("output should NOT contain %q\n\nGot:\n%s", notWant, got)
+				}
+			}
+		})
+	}
+}
+
+// ---------- T023: Exporter.Export tests ----------
+
+func TestExporterExport(t *testing.T) {
+	baseDate := time.Date(2026, 4, 18, 14, 0, 0, 0, time.UTC)
+	baseMeta := models.DecisionDocContext{
+		DocID:      "doc-123",
+		Source:     "notes-by-gemini",
+		EventTitle: "Weekly Sync",
+		EventDate:  baseDate,
+		Attendees:  []string{"alice@example.com"},
+	}
+	baseDecisions := []models.Decision{
+		{Category: "made", Text: "Adopt new pipeline"},
+	}
+
+	tests := []struct {
+		name           string
+		decisions      []models.Decision
+		meta           models.DecisionDocContext
+		dryRun         bool
+		writeFileErr   error
+		mkdirAllErr    error
+		wantErr        bool
+		wantWriteCalls int
+		wantMkdirCalls int
+	}{
+		{
+			name:           "successful write",
+			decisions:      baseDecisions,
+			meta:           baseMeta,
+			wantWriteCalls: 1,
+			wantMkdirCalls: 1,
+		},
+		{
+			name:           "directory creation",
+			decisions:      baseDecisions,
+			meta:           baseMeta,
+			wantMkdirCalls: 1,
+			wantWriteCalls: 1,
+		},
+		{
+			name:           "overwrite existing file (FR-008)",
+			decisions:      baseDecisions,
+			meta:           baseMeta,
+			wantWriteCalls: 1,
+			wantMkdirCalls: 1,
+		},
+		{
+			name:           "write failure logs warning (FR-012)",
+			decisions:      baseDecisions,
+			meta:           baseMeta,
+			writeFileErr:   fmt.Errorf("permission denied"),
+			wantErr:        true,
+			wantWriteCalls: 1,
+			wantMkdirCalls: 1,
+		},
+		{
+			name:           "mkdir failure logs warning (FR-012)",
+			decisions:      baseDecisions,
+			meta:           baseMeta,
+			mkdirAllErr:    fmt.Errorf("read-only filesystem"),
+			wantErr:        true,
+			wantWriteCalls: 0,
+			wantMkdirCalls: 1,
+		},
+		{
+			name:           "dry-run suppresses write (FR-011)",
+			decisions:      baseDecisions,
+			meta:           baseMeta,
+			dryRun:         true,
+			wantWriteCalls: 0,
+			wantMkdirCalls: 0,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			writeCalls := 0
+			mkdirCalls := 0
+			var lastWrittenPath string
+			var lastWrittenData []byte
+
+			mockWriteFile := func(name string, data []byte, perm os.FileMode) error {
+				writeCalls++
+				lastWrittenPath = name
+				lastWrittenData = data
+				return tt.writeFileErr
+			}
+			mockMkdirAll := func(path string, perm os.FileMode) error {
+				mkdirCalls++
+				return tt.mkdirAllErr
+			}
+
+			exporter := &Exporter{
+				writeFile: mockWriteFile,
+				mkdirAll:  mockMkdirAll,
+				logger:    testLogger(),
+				outputDir: "/tmp/test-decisions",
+			}
+
+			err := exporter.Export(context.Background(), tt.decisions, tt.meta, tt.dryRun)
+
+			if tt.wantErr && err == nil {
+				t.Error("expected error, got nil")
+			}
+			if !tt.wantErr && err != nil {
+				t.Errorf("unexpected error: %v", err)
+			}
+
+			if writeCalls != tt.wantWriteCalls {
+				t.Errorf("writeFile calls: got %d, want %d", writeCalls, tt.wantWriteCalls)
+			}
+			if mkdirCalls != tt.wantMkdirCalls {
+				t.Errorf("mkdirAll calls: got %d, want %d", mkdirCalls, tt.wantMkdirCalls)
+			}
+
+			// Verify file path format for successful writes
+			if writeCalls > 0 && tt.writeFileErr == nil {
+				expectedPath := "/tmp/test-decisions/weekly-sync-2026-04-18.md"
+				if lastWrittenPath != expectedPath {
+					t.Errorf("write path: got %q, want %q", lastWrittenPath, expectedPath)
+				}
+				// Verify content contains frontmatter
+				content := string(lastWrittenData)
+				if !strings.Contains(content, "topic: Weekly Sync") {
+					t.Errorf("written content missing topic frontmatter")
+				}
+			}
+		})
+	}
+}
+
+// ---------- T024: Zero-decisions edge case ----------
+
+func TestExporterExport_ZeroDecisions(t *testing.T) {
+	writeCalls := 0
+	mockWriteFile := func(name string, data []byte, perm os.FileMode) error {
+		writeCalls++
+		return nil
+	}
+	mockMkdirAll := func(path string, perm os.FileMode) error {
+		return nil
+	}
+
+	exporter := &Exporter{
+		writeFile: mockWriteFile,
+		mkdirAll:  mockMkdirAll,
+		logger:    testLogger(),
+		outputDir: "/tmp/test-decisions",
+	}
+
+	meta := models.DecisionDocContext{
+		DocID:      "doc-empty",
+		Source:     "transcript",
+		EventTitle: "Empty Meeting",
+		EventDate:  time.Date(2026, 4, 18, 0, 0, 0, 0, time.UTC),
+	}
+
+	err := exporter.Export(context.Background(), []models.Decision{}, meta, false)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	// Contract: no file created when decisions slice is empty
+	if writeCalls != 0 {
+		t.Errorf("writeFile should not be called for zero decisions, got %d calls", writeCalls)
+	}
+}
+
+// ---------- T033: Frontmatter with attendees ----------
+
+func TestRenderMarkdown_WithAttendees(t *testing.T) {
+	decisions := []models.Decision{
+		{Category: "made", Text: "Ship it"},
+	}
+	attendees := []string{"alice@example.com", "bob@example.com", "carol@example.com"}
+	date := time.Date(2026, 4, 18, 0, 0, 0, 0, time.UTC)
+
+	got := string(renderMarkdown(decisions, "Team Sync", date, attendees))
+
+	// Verify YAML attendees list renders correctly
+	if !strings.Contains(got, "attendees:\n  - alice@example.com\n  - bob@example.com\n  - carol@example.com\n") {
+		t.Errorf("attendees list not rendered correctly\n\nGot:\n%s", got)
+	}
+}
+
+// ---------- T034: Frontmatter without attendees ----------
+
+func TestRenderMarkdown_WithoutAttendees(t *testing.T) {
+	decisions := []models.Decision{
+		{Category: "made", Text: "Ship it"},
+	}
+	date := time.Date(2026, 4, 18, 0, 0, 0, 0, time.UTC)
+
+	// Test with nil attendees
+	got := string(renderMarkdown(decisions, "Solo Meeting", date, nil))
+	if strings.Contains(got, "attendees:") {
+		t.Errorf("attendees field should be omitted when nil\n\nGot:\n%s", got)
+	}
+
+	// Test with empty slice
+	got = string(renderMarkdown(decisions, "Solo Meeting", date, []string{}))
+	if strings.Contains(got, "attendees:") {
+		t.Errorf("attendees field should be omitted when empty\n\nGot:\n%s", got)
+	}
+}
+
+// ---------- T035: Topic cleaning tests ----------
+
+func TestCleanTopic(t *testing.T) {
+	tests := []struct {
+		input string
+		want  string
+	}{
+		{"Weekly Sync - Transcript", "Weekly Sync"},
+		{"Notes by Gemini - Project Alpha", "Project Alpha"},
+		{"Notes by Gemini", "Meeting"},
+		{"Regular Meeting Title", "Regular Meeting Title"},
+		{"", "Meeting"},
+		{"Design Review: API v2", "Design Review: API v2"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.input, func(t *testing.T) {
+			got := CleanTopic(tt.input)
+			if got != tt.want {
+				t.Errorf("CleanTopic(%q) = %q, want %q", tt.input, got, tt.want)
+			}
+		})
+	}
+}

--- a/internal/export/slug.go
+++ b/internal/export/slug.go
@@ -1,0 +1,72 @@
+// Package export provides markdown file export for extracted meeting decisions.
+//
+// slug.go implements topic slug generation for decision export filenames.
+// Slugs are kebab-case, filename-safe strings derived from meeting titles.
+package export
+
+import (
+	"regexp"
+	"strings"
+)
+
+// nonAlphanumHyphen matches any character that is not a lowercase letter,
+// digit, or hyphen. Used to sanitize topic slugs for filenames.
+var nonAlphanumHyphen = regexp.MustCompile(`[^a-z0-9-]`)
+
+// consecutiveHyphens matches two or more consecutive hyphens for collapsing.
+var consecutiveHyphens = regexp.MustCompile(`-{2,}`)
+
+// TopicSlug converts a meeting title into a kebab-case, filename-safe slug.
+//
+// Rules (per data-model.md):
+//  1. Strip known prefixes (case-insensitive): "Notes by Gemini - ", "Notes by Gemini"
+//  2. Strip known suffixes (case-insensitive): " - Transcript", "- Transcript"
+//  3. Trim whitespace
+//  4. Convert to lowercase
+//  5. Replace any character not in [a-z0-9-] with a hyphen
+//  6. Collapse consecutive hyphens to a single hyphen
+//  7. Trim leading/trailing hyphens
+//  8. Fallback to "meeting" for empty result
+func TopicSlug(title string) string {
+	s := title
+
+	// 1. Strip known prefixes (case-insensitive)
+	prefixes := []string{"Notes by Gemini - ", "Notes by Gemini"}
+	for _, prefix := range prefixes {
+		if len(s) >= len(prefix) && strings.EqualFold(s[:len(prefix)], prefix) {
+			s = s[len(prefix):]
+			break
+		}
+	}
+
+	// 2. Strip known suffixes (case-insensitive)
+	suffixes := []string{" - Transcript", "- Transcript"}
+	for _, suffix := range suffixes {
+		if len(s) >= len(suffix) && strings.EqualFold(s[len(s)-len(suffix):], suffix) {
+			s = s[:len(s)-len(suffix)]
+			break
+		}
+	}
+
+	// 3. Trim whitespace
+	s = strings.TrimSpace(s)
+
+	// 4. Convert to lowercase
+	s = strings.ToLower(s)
+
+	// 5. Replace non-alphanumeric (except hyphens) with hyphens
+	s = nonAlphanumHyphen.ReplaceAllString(s, "-")
+
+	// 6. Collapse consecutive hyphens
+	s = consecutiveHyphens.ReplaceAllString(s, "-")
+
+	// 7. Trim leading/trailing hyphens
+	s = strings.Trim(s, "-")
+
+	// 8. Fallback for empty result
+	if s == "" {
+		return "meeting"
+	}
+
+	return s
+}

--- a/internal/export/slug_test.go
+++ b/internal/export/slug_test.go
@@ -1,0 +1,88 @@
+package export
+
+import "testing"
+
+// ---------- T012: TopicSlug table-driven tests ----------
+
+func TestTopicSlug(t *testing.T) {
+	tests := []struct {
+		name  string
+		input string
+		want  string
+	}{
+		{
+			name:  "standard meeting title",
+			input: "Weekly Engineering Sync",
+			want:  "weekly-engineering-sync",
+		},
+		{
+			name:  "Notes by Gemini prefix only",
+			input: "Notes by Gemini",
+			want:  "meeting",
+		},
+		{
+			name:  "Transcript suffix",
+			input: "Project Alpha - Transcript",
+			want:  "project-alpha",
+		},
+		{
+			name:  "slash in title",
+			input: "Q3 Budget / Planning",
+			want:  "q3-budget-planning",
+		},
+		{
+			name:  "colon in title",
+			input: "Design Review: API v2",
+			want:  "design-review-api-v2",
+		},
+		{
+			name:  "empty string fallback",
+			input: "",
+			want:  "meeting",
+		},
+		{
+			name:  "Notes by Gemini with dash prefix",
+			input: "Notes by Gemini - Weekly Standup",
+			want:  "weekly-standup",
+		},
+		{
+			name:  "long transcript title",
+			input: "ComplyTime Standup - 2026/02/25 14:00 WET - Transcript",
+			want:  "complytime-standup-2026-02-25-14-00-wet",
+		},
+		{
+			name:  "multiple special characters",
+			input: "Q&A: Team @All — Review #42",
+			want:  "q-a-team-all-review-42",
+		},
+		{
+			name:  "leading and trailing spaces",
+			input: "  Spaced Title  ",
+			want:  "spaced-title",
+		},
+		{
+			name:  "only special characters",
+			input: "///",
+			want:  "meeting",
+		},
+		{
+			name:  "case insensitive prefix stripping",
+			input: "notes by gemini - Test",
+			want:  "test",
+		},
+		{
+			name:  "case insensitive suffix stripping",
+			input: "Meeting - transcript",
+			want:  "meeting",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := TopicSlug(tt.input)
+			if got != tt.want {
+				t.Errorf("TopicSlug(%q) = %q, want %q", tt.input, got, tt.want)
+			}
+		})
+	}
+}

--- a/internal/organizer/organizer.go
+++ b/internal/organizer/organizer.go
@@ -50,20 +50,22 @@ type GeminiService interface {
 
 // Stats tracks operation counts for summary reporting.
 type Stats struct {
-	DocumentsFound     int
-	DocumentsMoved     int
-	ShortcutsCreated   int
-	ShortcutsTrashed   int
-	EventsProcessed    int
-	EventsWithAttach   int
-	AttachmentsShared  int
-	TasksAssigned      int
-	TasksFailed        int
-	DecisionsProcessed int
-	DecisionsSkipped   int
-	DecisionsFailed    int
-	Skipped            int
-	Errors             int
+	DocumentsFound        int
+	DocumentsMoved        int
+	ShortcutsCreated      int
+	ShortcutsTrashed      int
+	EventsProcessed       int
+	EventsWithAttach      int
+	AttachmentsShared     int
+	TasksAssigned         int
+	TasksFailed           int
+	DecisionsProcessed    int
+	DecisionsSkipped      int
+	DecisionsFailed       int
+	DecisionsExported     int
+	DecisionsExportFailed int
+	Skipped               int
+	Errors                int
 }
 
 // Organizer orchestrates all the services.
@@ -73,20 +75,20 @@ type Organizer struct {
 	calendar CalendarService
 	logger   *log.Logger
 
-	stats          Stats
-	notesDocIDs    map[string]bool   // Google Doc IDs with "Notes" attachments
-	decisionDocIDs map[string]string // Google Doc IDs for decision extraction (docID→source)
+	stats               Stats
+	notesDocIDs         map[string]bool                      // Google Doc IDs with "Notes" attachments
+	decisionDocContexts map[string]models.DecisionDocContext // Google Doc IDs for decision extraction (docID→context)
 }
 
 // New creates a new Organizer with all services initialized.
 func New(cfg *config.Config, driveSvc DriveService, calSvc CalendarService) *Organizer {
 	return &Organizer{
-		config:         cfg,
-		drive:          driveSvc,
-		calendar:       calSvc,
-		logger:         logging.Logger,
-		notesDocIDs:    make(map[string]bool),
-		decisionDocIDs: make(map[string]string),
+		config:              cfg,
+		drive:               driveSvc,
+		calendar:            calSvc,
+		logger:              logging.Logger,
+		notesDocIDs:         make(map[string]bool),
+		decisionDocContexts: make(map[string]models.DecisionDocContext),
 	}
 }
 
@@ -99,11 +101,11 @@ func (o *Organizer) GetNotesDocIDs() []string {
 	return ids
 }
 
-// GetDecisionDocIDs returns a copy of the map of Google Doc IDs eligible for decision extraction.
-// Keys are doc IDs, values are the source pattern ("notes-by-gemini" or "transcript").
-func (o *Organizer) GetDecisionDocIDs() map[string]string {
-	result := make(map[string]string, len(o.decisionDocIDs))
-	for k, v := range o.decisionDocIDs {
+// GetDecisionDocContexts returns a copy of the map of Google Doc IDs eligible for decision extraction.
+// Keys are doc IDs, values are DecisionDocContext structs carrying event metadata.
+func (o *Organizer) GetDecisionDocContexts() map[string]models.DecisionDocContext {
+	result := make(map[string]models.DecisionDocContext, len(o.decisionDocContexts))
+	for k, v := range o.decisionDocContexts {
 		result[k] = v
 	}
 	return result
@@ -152,10 +154,20 @@ func (o *Organizer) AddDecisionStats(processed, skipped, failed int) {
 	o.stats.DecisionsFailed += failed
 }
 
+// DecisionExporter defines the interface for exporting decisions to local files.
+// Extracted as an interface to allow the organizer to call the exporter without
+// importing the export package directly (avoiding circular dependencies).
+type DecisionExporter interface {
+	Export(ctx context.Context, decisions []models.Decision, meta models.DecisionDocContext, dryRun bool) error
+}
+
 // ExtractDecisionsForDoc orchestrates decision extraction for a single document.
-// It extracts the transcript, calls Gemini for decision extraction, and creates
-// the Decisions tab. Skips on AI failure with a warning (FR-017).
-func (o *Organizer) ExtractDecisionsForDoc(ctx context.Context, docID string, docsSvc DocsService, geminiSvc GeminiService, dryRun bool) error {
+// It extracts the transcript, calls Gemini for decision extraction, creates
+// the Decisions tab, and exports decisions as local markdown. Skips on AI
+// failure with a warning (FR-017). Export failure does not block the pipeline (FR-012).
+func (o *Organizer) ExtractDecisionsForDoc(ctx context.Context, docCtx models.DecisionDocContext, docsSvc DocsService, geminiSvc GeminiService, exporter DecisionExporter, dryRun bool) error {
+	docID := docCtx.DocID
+
 	// Check for existing Decisions tab (idempotency — FR-005)
 	hasTab, err := docsSvc.HasDecisionsTab(ctx, docID)
 	if err != nil {
@@ -185,6 +197,10 @@ func (o *Organizer) ExtractDecisionsForDoc(ctx context.Context, docID string, do
 			"transcript_chars", len(transcript.FullText),
 			"headings", len(transcript.Headings),
 		)
+		// Delegate dry-run export logging to the exporter (FR-011)
+		if exporter != nil {
+			_ = exporter.Export(ctx, []models.Decision{{Category: "made", Text: "placeholder"}}, docCtx, true)
+		}
 		o.stats.DecisionsProcessed++
 		return nil
 	}
@@ -219,6 +235,19 @@ func (o *Organizer) ExtractDecisionsForDoc(ctx context.Context, docID string, do
 		return fmt.Errorf("create decisions tab: %w", err)
 	}
 
+	// Export decisions as local markdown (FR-012: failure must not block pipeline)
+	if exporter != nil && len(decisions) > 0 {
+		if exportErr := exporter.Export(ctx, decisions, docCtx, false); exportErr != nil {
+			o.logger.Warn("Decision markdown export failed",
+				"docID", docID,
+				"error", exportErr,
+			)
+			o.stats.DecisionsExportFailed++
+		} else {
+			o.stats.DecisionsExported++
+		}
+	}
+
 	o.stats.DecisionsProcessed++
 	return nil
 }
@@ -235,6 +264,9 @@ func (o *Organizer) printSummary() {
 		)
 		if o.stats.DecisionsProcessed > 0 {
 			o.logger.Info("Would extract decisions", "documents", o.stats.DecisionsProcessed)
+		}
+		if o.stats.DecisionsExported > 0 {
+			o.logger.Info("Would export decisions", "count", o.stats.DecisionsExported)
 		}
 		if o.stats.Skipped > 0 {
 			o.logger.Info("Would skip non-owned files (--owned-only active)", "count", o.stats.Skipped)
@@ -254,6 +286,12 @@ func (o *Organizer) printSummary() {
 				"processed", o.stats.DecisionsProcessed,
 				"skipped", o.stats.DecisionsSkipped,
 				"failed", o.stats.DecisionsFailed,
+			)
+		}
+		if o.stats.DecisionsExported > 0 || o.stats.DecisionsExportFailed > 0 {
+			o.logger.Info("Decision export",
+				"decisions_exported", o.stats.DecisionsExported,
+				"decisions_export_failed", o.stats.DecisionsExportFailed,
 			)
 		}
 		if o.stats.ShortcutsTrashed > 0 {
@@ -447,7 +485,22 @@ func (o *Organizer) SyncCalendarAttachments(ctx context.Context) error {
 				}
 			}
 			if eventDecisionDocID != "" {
-				o.decisionDocIDs[eventDecisionDocID] = eventDecisionSource
+				// Build attendee list, filtering out self and resource addresses
+				var attendees []string
+				for _, att := range event.Attendees {
+					if att.IsSelf || att.Email == "" || isCalendarResource(att.Email) {
+						continue
+					}
+					attendees = append(attendees, att.Email)
+				}
+
+				o.decisionDocContexts[eventDecisionDocID] = models.DecisionDocContext{
+					DocID:      eventDecisionDocID,
+					Source:     eventDecisionSource,
+					EventTitle: event.Title,
+					EventDate:  event.Start,
+					Attendees:  attendees,
+				}
 			}
 		}
 

--- a/internal/organizer/organizer_test.go
+++ b/internal/organizer/organizer_test.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/jflowers/gcal-organizer/internal/config"
 	"github.com/jflowers/gcal-organizer/internal/docs"
@@ -164,13 +165,26 @@ func (m *mockCalendarService) ListRecentEvents(_ context.Context, _ int) ([]*mod
 // setupOrganizer creates an Organizer with mock services for testing.
 func setupOrganizer(cfg *config.Config, driveMock *mockDriveService, calMock *mockCalendarService) *Organizer {
 	return &Organizer{
-		config:         cfg,
-		drive:          driveMock,
-		calendar:       calMock,
-		logger:         logging.Logger,
-		notesDocIDs:    make(map[string]bool),
-		decisionDocIDs: make(map[string]string),
+		config:              cfg,
+		drive:               driveMock,
+		calendar:            calMock,
+		logger:              logging.Logger,
+		notesDocIDs:         make(map[string]bool),
+		decisionDocContexts: make(map[string]models.DecisionDocContext),
 	}
+}
+
+// mockDecisionExporter implements DecisionExporter for testing.
+type mockDecisionExporter struct {
+	exportCalls int
+	exportErr   error
+	lastMeta    models.DecisionDocContext
+}
+
+func (m *mockDecisionExporter) Export(_ context.Context, _ []models.Decision, meta models.DecisionDocContext, _ bool) error {
+	m.exportCalls++
+	m.lastMeta = meta
+	return m.exportErr
 }
 
 // ---------- T009: OrganizeDocuments ownership filtering tests ----------
@@ -621,19 +635,19 @@ func TestDecisionDocCollection(t *testing.T) {
 				t.Fatalf("unexpected error: %v", err)
 			}
 
-			gotDocIDs := org.GetDecisionDocIDs()
-			if len(gotDocIDs) != tt.wantDocCount {
-				t.Errorf("expected %d decision doc IDs, got %d: %v", tt.wantDocCount, len(gotDocIDs), gotDocIDs)
+			gotDocContexts := org.GetDecisionDocContexts()
+			if len(gotDocContexts) != tt.wantDocCount {
+				t.Errorf("expected %d decision doc contexts, got %d: %v", tt.wantDocCount, len(gotDocContexts), gotDocContexts)
 			}
 
 			for wantID, wantSource := range tt.wantDocIDs {
-				gotSource, ok := gotDocIDs[wantID]
+				gotCtx, ok := gotDocContexts[wantID]
 				if !ok {
-					t.Errorf("expected doc ID %s in decisionDocIDs, but not found", wantID)
+					t.Errorf("expected doc ID %s in decisionDocContexts, but not found", wantID)
 					continue
 				}
-				if gotSource != wantSource {
-					t.Errorf("doc %s: expected source %q, got %q", wantID, wantSource, gotSource)
+				if gotCtx.Source != wantSource {
+					t.Errorf("doc %s: expected source %q, got %q", wantID, wantSource, gotCtx.Source)
 				}
 			}
 		})
@@ -1361,8 +1375,8 @@ func TestSyncCalendarAttachments_EmptyEventsList(t *testing.T) {
 	if len(org.GetNotesDocIDs()) != 0 {
 		t.Errorf("notesDocIDs: got %d, want 0", len(org.GetNotesDocIDs()))
 	}
-	if len(org.GetDecisionDocIDs()) != 0 {
-		t.Errorf("decisionDocIDs: got %d, want 0", len(org.GetDecisionDocIDs()))
+	if len(org.GetDecisionDocContexts()) != 0 {
+		t.Errorf("decisionDocContexts: got %d, want 0", len(org.GetDecisionDocContexts()))
 	}
 }
 
@@ -1467,8 +1481,8 @@ func TestNew(t *testing.T) {
 	if org.notesDocIDs == nil {
 		t.Error("New did not initialize notesDocIDs map")
 	}
-	if org.decisionDocIDs == nil {
-		t.Error("New did not initialize decisionDocIDs map")
+	if org.decisionDocContexts == nil {
+		t.Error("New did not initialize decisionDocContexts map")
 	}
 }
 
@@ -1894,7 +1908,16 @@ func TestExtractDecisionsForDoc(t *testing.T) {
 			cfg := config.DefaultConfig()
 			org := setupOrganizer(cfg, driveMock, calMock)
 
-			err := org.ExtractDecisionsForDoc(context.Background(), "test-doc-id", tt.docsSvc, tt.geminiSvc, tt.dryRun)
+			docCtx := models.DecisionDocContext{
+				DocID:      "test-doc-id",
+				Source:     "notes-by-gemini",
+				EventTitle: "Test Meeting",
+				EventDate:  time.Date(2026, 4, 18, 14, 0, 0, 0, time.UTC),
+				Attendees:  []string{"alice@example.com"},
+			}
+			exporter := &mockDecisionExporter{}
+
+			err := org.ExtractDecisionsForDoc(context.Background(), docCtx, tt.docsSvc, tt.geminiSvc, exporter, tt.dryRun)
 
 			if tt.wantErr {
 				if err == nil {
@@ -1927,5 +1950,105 @@ func TestExtractDecisionsForDoc(t *testing.T) {
 				t.Errorf("ExtractDecisions calls: got %d, want %d", tt.geminiSvc.extractCalls, tt.wantGeminiCalls)
 			}
 		})
+	}
+}
+
+// ---------- T024b: Integration test for ExtractDecisionsForDoc with exporter ----------
+
+func TestExtractDecisionsForDoc_ExporterCalled(t *testing.T) {
+	// Verify exporter is called after CreateDecisionsTab succeeds
+	docsSvc := &mockDocsService{
+		hasDecisionsTab: false,
+		transcriptContent: &models.TranscriptContent{
+			TabID:    "tab1",
+			FullText: "Meeting transcript with decisions",
+		},
+	}
+	geminiSvc := &mockGeminiService{
+		decisions: []models.Decision{
+			{Category: "made", Text: "Adopt new pipeline"},
+		},
+	}
+	exporter := &mockDecisionExporter{}
+
+	driveMock := &mockDriveService{}
+	calMock := &mockCalendarService{}
+	cfg := config.DefaultConfig()
+	org := setupOrganizer(cfg, driveMock, calMock)
+
+	docCtx := models.DecisionDocContext{
+		DocID:      "test-doc-id",
+		Source:     "notes-by-gemini",
+		EventTitle: "Weekly Sync",
+		EventDate:  time.Date(2026, 4, 18, 14, 0, 0, 0, time.UTC),
+		Attendees:  []string{"alice@example.com"},
+	}
+
+	err := org.ExtractDecisionsForDoc(context.Background(), docCtx, docsSvc, geminiSvc, exporter, false)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	// Contract: exporter was called
+	if exporter.exportCalls != 1 {
+		t.Errorf("Export calls: got %d, want 1", exporter.exportCalls)
+	}
+
+	// Contract: export stats incremented
+	if org.stats.DecisionsExported != 1 {
+		t.Errorf("DecisionsExported: got %d, want 1", org.stats.DecisionsExported)
+	}
+}
+
+func TestExtractDecisionsForDoc_ExportFailureDoesNotBlockPipeline(t *testing.T) {
+	// FR-012: export failure must not cause ExtractDecisionsForDoc to return an error
+	docsSvc := &mockDocsService{
+		hasDecisionsTab: false,
+		transcriptContent: &models.TranscriptContent{
+			TabID:    "tab1",
+			FullText: "Meeting transcript with decisions",
+		},
+	}
+	geminiSvc := &mockGeminiService{
+		decisions: []models.Decision{
+			{Category: "made", Text: "Adopt new pipeline"},
+		},
+	}
+	exporter := &mockDecisionExporter{
+		exportErr: fmt.Errorf("permission denied"),
+	}
+
+	driveMock := &mockDriveService{}
+	calMock := &mockCalendarService{}
+	cfg := config.DefaultConfig()
+	org := setupOrganizer(cfg, driveMock, calMock)
+
+	docCtx := models.DecisionDocContext{
+		DocID:      "test-doc-id",
+		Source:     "notes-by-gemini",
+		EventTitle: "Weekly Sync",
+		EventDate:  time.Date(2026, 4, 18, 14, 0, 0, 0, time.UTC),
+		Attendees:  []string{"alice@example.com"},
+	}
+
+	// FR-012: ExtractDecisionsForDoc must NOT return an error when export fails
+	err := org.ExtractDecisionsForDoc(context.Background(), docCtx, docsSvc, geminiSvc, exporter, false)
+	if err != nil {
+		t.Fatalf("ExtractDecisionsForDoc should not return error on export failure, got: %v", err)
+	}
+
+	// Contract: CreateDecisionsTab was still called successfully
+	if docsSvc.createDecisionsTabCalls != 1 {
+		t.Errorf("CreateDecisionsTab calls: got %d, want 1", docsSvc.createDecisionsTabCalls)
+	}
+
+	// Contract: export failure tracked in stats
+	if org.stats.DecisionsExportFailed != 1 {
+		t.Errorf("DecisionsExportFailed: got %d, want 1", org.stats.DecisionsExportFailed)
+	}
+
+	// Contract: decisions still counted as processed
+	if org.stats.DecisionsProcessed != 1 {
+		t.Errorf("DecisionsProcessed: got %d, want 1", org.stats.DecisionsProcessed)
 	}
 }

--- a/pkg/models/models.go
+++ b/pkg/models/models.go
@@ -127,6 +127,22 @@ type TranscriptContent struct {
 	Headings []TranscriptHeading `json:"headings"`
 }
 
+// DecisionDocContext carries meeting metadata alongside a Google Doc ID
+// for the decision extraction pipeline. Provides event title, date, and
+// attendees needed for markdown export.
+type DecisionDocContext struct {
+	// DocID is the Google Drive file ID
+	DocID string
+	// Source indicates which attachment pattern matched ("notes-by-gemini" or "transcript")
+	Source string
+	// EventTitle is the calendar event title, used to derive topic slug and frontmatter
+	EventTitle string
+	// EventDate is the calendar event start time, used for filename and frontmatter
+	EventDate time.Time
+	// Attendees are attendee email addresses (excluding self and resources)
+	Attendees []string
+}
+
 // Attendee represents a calendar event attendee.
 type Attendee struct {
 	// Email is the attendee's email address

--- a/specs/012-decision-markdown-export/checklists/requirements.md
+++ b/specs/012-decision-markdown-export/checklists/requirements.md
@@ -1,0 +1,36 @@
+# Specification Quality Checklist: Decision Markdown Export
+
+**Purpose**: Validate specification completeness and quality before proceeding to planning
+**Created**: 2026-04-19
+**Feature**: [spec.md](../spec.md)
+
+## Content Quality
+
+- [x] No implementation details (languages, frameworks, APIs)
+- [x] Focused on user value and business needs
+- [x] Written for non-technical stakeholders
+- [x] All mandatory sections completed
+
+## Requirement Completeness
+
+- [x] No [NEEDS CLARIFICATION] markers remain
+- [x] Requirements are testable and unambiguous
+- [x] Success criteria are measurable
+- [x] Success criteria are technology-agnostic (no implementation details)
+- [x] All acceptance scenarios are defined
+- [x] Edge cases are identified
+- [x] Scope is clearly bounded
+- [x] Dependencies and assumptions identified
+
+## Feature Readiness
+
+- [x] All functional requirements have clear acceptance criteria
+- [x] User scenarios cover primary flows
+- [x] Feature meets measurable outcomes defined in Success Criteria
+- [x] No implementation details leak into specification
+
+## Notes
+
+- All items passed on first validation iteration.
+- Spec derived from GitHub Issue #12 which provided detailed design considerations and example output, reducing ambiguity.
+- No [NEEDS CLARIFICATION] markers needed — the issue provided sufficient context to make informed decisions on all aspects.

--- a/specs/012-decision-markdown-export/data-model.md
+++ b/specs/012-decision-markdown-export/data-model.md
@@ -1,0 +1,146 @@
+# Data Model: Decision Markdown Export
+
+**Feature**: `012-decision-markdown-export` | **Date**: 2026-04-19
+
+## Entities
+
+### DecisionDocContext (new)
+
+Replaces the existing `map[string]string` (`decisionDocIDs`) in the organizer with a richer struct that carries meeting metadata needed for markdown export.
+
+| Field | Type | Description | Constraints |
+|-------|------|-------------|-------------|
+| DocID | string | Google Drive file ID | Non-empty |
+| Source | string | Which attachment pattern matched | `"notes-by-gemini"` or `"transcript"` |
+| EventTitle | string | Calendar event title | Non-empty; used to derive topic slug and frontmatter `topic` |
+| EventDate | time.Time | Calendar event start time | Used for filename date component and frontmatter `date` |
+| Attendees | []string | Attendee email addresses (excluding self and resources) | May be empty; omitted from frontmatter when empty |
+
+**Validation rules**:
+- `DocID` must be non-empty
+- `Source` must be one of the two allowed values
+- `EventTitle` must be non-empty (calendar events always have titles)
+- Per-event deduplication: if both sources match on the same event, only `"notes-by-gemini"` is kept (existing behavior preserved)
+
+**Notes**: This struct is internal to the organizer package. It is populated during `SyncCalendarAttachments` and consumed by `ExtractDecisionsForDoc`. It is transient — not persisted.
+
+### DecisionExportFile (conceptual — output artifact)
+
+Represents the markdown file written to disk. Not a Go struct — it's the rendered output.
+
+| Component | Format | Description | Constraints |
+|-----------|--------|-------------|-------------|
+| Filename | `<topic-slug>-<YYYY-MM-DD>.md` | Kebab-case topic + ISO date | FR-002 |
+| Frontmatter `topic` | string | Clean meeting topic (prefixes/suffixes stripped) | FR-005, FR-013 |
+| Frontmatter `date` | string | ISO 8601 date (`YYYY-MM-DD`) | FR-005 |
+| Frontmatter `attendees` | list of strings | Attendee emails | FR-006; omitted when empty |
+| Section: Decisions Made | `## Decisions Made` | Level-2 heading + bullet items | FR-003, FR-004; omitted if no "made" decisions (FR-015) |
+| Section: Decisions Deferred | `## Decisions Deferred` | Level-2 heading + bullet items | FR-003, FR-004; omitted if no "deferred" decisions (FR-015) |
+| Section: Open Items | `## Open Items` | Level-2 heading + bullet items | FR-003, FR-004; omitted if no "open" decisions (FR-015) |
+
+**Example output**:
+
+```markdown
+---
+topic: Weekly Engineering Sync
+date: "2026-04-18"
+attendees:
+  - alice@example.com
+  - bob@example.com
+---
+
+## Decisions Made
+
+- Team will adopt GitHub Actions for CI/CD
+- Budget approved for Q3 infrastructure upgrade
+
+## Open Items
+
+- Whether to migrate to new API version — need benchmarks first
+```
+
+### Exporter (new Go struct)
+
+The service responsible for rendering decisions as markdown and writing them to disk.
+
+| Field | Type | Description | Constraints |
+|-------|------|-------------|-------------|
+| outputDir | string | Resolved absolute path to the export directory | Expanded from `~`; created on first write |
+| writeFile | func(string, []byte, os.FileMode) error | Injected file writer | Defaults to `os.WriteFile` in production |
+| mkdirAll | func(string, os.FileMode) error | Injected directory creator | Defaults to `os.MkdirAll` in production |
+| logger | *log.Logger | Structured logger | From `logging.Logger` |
+
+**Methods**:
+
+| Method | Signature | Description |
+|--------|-----------|-------------|
+| Export | `Export(ctx context.Context, decisions []models.Decision, meta DecisionDocContext, dryRun bool) error` | Renders markdown and writes to disk. Returns nil on success or dry-run. Logs warning on write failure (FR-012). |
+
+**Notes**: The `Exporter` is created once per run and reused for all documents. The `outputDir` is resolved at construction time.
+
+### ExportConfiguration (addition to existing Config)
+
+| Field | Type | Description | Constraints |
+|-------|------|-------------|-------------|
+| DecisionsExportDir | string | Output directory for decision markdown files | Default: `~/.gcal-organizer/decisions/`. Configurable via config file or `GCAL_DECISIONS_EXPORT_DIR` env var. `~` expanded at load time. |
+
+## Entity Relationships
+
+```text
+CalendarEvent (existing)
+  └── Attachment (existing)
+        └── DecisionDocContext (new, replaces map entry)
+              ├── EventTitle → TopicSlug() → filename
+              ├── EventDate → filename + frontmatter
+              ├── Attendees → frontmatter
+              └── Decision[] (existing, from Gemini)
+                    └── DecisionExportFile (new, rendered output)
+```
+
+## Modified Entities
+
+### Config (existing — `internal/config/config.go`)
+
+**Added field**:
+- `DecisionsExportDir string` — default `~/.gcal-organizer/decisions/`
+
+**Added viper binding**:
+- `mustBindEnv("decisions_export_dir", "GCAL_DECISIONS_EXPORT_DIR")`
+
+### Organizer (existing — `internal/organizer/organizer.go`)
+
+**Changed field**:
+- `decisionDocIDs map[string]string` → `decisionDocContexts map[string]DecisionDocContext`
+
+**Changed methods**:
+- `GetDecisionDocIDs() map[string]string` → `GetDecisionDocContexts() map[string]DecisionDocContext`
+- `ExtractDecisionsForDoc()` — gains `exporter` parameter or receives it at construction
+
+### Stats (existing — `internal/organizer/organizer.go`)
+
+**Added fields**:
+- `DecisionsExported int` — count of successfully written markdown files
+- `DecisionsExportFailed int` — count of failed markdown writes (logged as warnings)
+
+## Slug Generation Rules
+
+The `TopicSlug(title string) string` function in `internal/export/slug.go`:
+
+1. Strip known prefixes (case-insensitive): `"Notes by Gemini"`, `"Notes by Gemini - "`
+2. Strip known suffixes (case-insensitive): `"- Transcript"`, `" - Transcript"`
+3. Trim whitespace
+4. Convert to lowercase
+5. Replace any character not in `[a-z0-9-]` with `-`
+6. Collapse consecutive hyphens to single hyphen
+7. Trim leading/trailing hyphens
+
+**Examples**:
+
+| Input | Output |
+|-------|--------|
+| `"Weekly Engineering Sync"` | `weekly-engineering-sync` |
+| `"Notes by Gemini"` | (empty after stripping — use fallback `"meeting"`) |
+| `"Project Alpha - Transcript"` | `project-alpha` |
+| `"Q3 Budget / Planning"` | `q3-budget-planning` |
+| `"Design Review: API v2"` | `design-review-api-v2` |
+| `""` | `meeting` (fallback for empty input) |

--- a/specs/012-decision-markdown-export/plan.md
+++ b/specs/012-decision-markdown-export/plan.md
@@ -1,0 +1,87 @@
+# Implementation Plan: Decision Markdown Export
+
+**Branch**: `012-decision-markdown-export` | **Date**: 2026-04-19 | **Spec**: [spec.md](spec.md)
+**Input**: Feature specification from `/specs/012-decision-markdown-export/spec.md`
+
+## Summary
+
+Add a local markdown export step to the existing decision extraction pipeline (spec 008). After writing decisions to a Google Docs "Decisions" tab, the system also writes a markdown copy to a configurable local directory (`~/.gcal-organizer/decisions/` by default). Each file uses YAML frontmatter (`topic`, `date`, `attendees`) and standard markdown headings (`## Decisions Made`, `## Decisions Deferred`, `## Open Items`), making files natively indexable by Dewey and other semantic search tools.
+
+The implementation hooks into `organizer.ExtractDecisionsForDoc()` — the existing orchestration point — and adds a new `internal/export` package responsible for rendering and writing markdown files. No new CLI commands or flags are introduced beyond a new config key (`decisions_export_dir`). The `--dry-run` flag already threaded through the pipeline suppresses file writes.
+
+## Technical Context
+
+**Language/Version**: Go 1.24.0 (toolchain go1.24.12)
+**Primary Dependencies**: `github.com/spf13/cobra` (CLI), `github.com/spf13/viper` (config), `github.com/charmbracelet/log` (logging) — all existing; no new dependencies
+**Storage**: Local filesystem (`~/.gcal-organizer/decisions/` default). No database.
+**Testing**: `go test -race ./...` — table-driven tests, mock interfaces for filesystem operations
+**Target Platform**: macOS (primary), Linux (secondary) — same as existing CLI
+**Project Type**: Single CLI application
+**Performance Goals**: N/A — file writes are negligible compared to Google API calls
+**Constraints**: No new external dependencies. Must not break existing decision extraction pipeline. Local export failure must not block Google Docs tab creation (FR-012).
+**Scale/Scope**: Typically 1–10 decision files per run (one per meeting with decisions)
+
+## Constitution Check
+
+*GATE: Must pass before Phase 0 research. Re-check after Phase 1 design.*
+
+| Principle | Status | Notes |
+|-----------|--------|-------|
+| I. CLI-First Architecture | ✅ PASS | No new commands; hooks into existing `run` workflow. Config via viper. |
+| II. API-Key Authentication | ✅ PASS | No new auth. Reuses existing pipeline context. |
+| III. Test-Driven Development | ✅ PASS | All new code (export package, slug generation, markdown rendering) will have unit tests. |
+| IV. Idiomatic Go | ✅ PASS | New `internal/export` package follows standard layout. Error returns, `context.Context`, no panics. |
+| V. Graceful Error Handling | ✅ PASS | FR-012: export failure logs warning, does not block pipeline. Errors wrapped with `fmt.Errorf` + `%w`. |
+| VI. Observability | ✅ PASS | FR-011: `--dry-run` suppresses writes and logs what would happen. Export actions logged. |
+| VII. Self-Serve Diagnostics | ✅ PASS | No new diagnostic commands needed. |
+| Quality Gates | ✅ PASS | `make ci` mirrors GitHub Actions. No gate modifications. |
+| Documentation | ✅ PASS | README.md, config examples updated. |
+| YAGNI | ✅ PASS | Writes files only. No Dewey API integration. Zero coupling. |
+
+**Post-Phase 1 Re-check**: All gates still pass. The `internal/export` package is a pure function layer (decisions in → file out) with injected filesystem, fully testable without external resources.
+
+## Project Structure
+
+### Documentation (this feature)
+
+```text
+specs/012-decision-markdown-export/
+├── plan.md              # This file
+├── research.md          # Phase 0 output
+├── data-model.md        # Phase 1 output
+├── quickstart.md        # Phase 1 output
+└── tasks.md             # Phase 2 output (created by /speckit.tasks)
+```
+
+### Source Code (repository root)
+
+```text
+internal/
+├── export/              # NEW — markdown export package
+│   ├── export.go        # DecisionExporter: render + write markdown files
+│   ├── export_test.go   # Table-driven tests for rendering and file writing
+│   ├── slug.go          # Topic slug generation (kebab-case, filename-safe)
+│   └── slug_test.go     # Slug generation tests
+├── config/
+│   └── config.go        # MODIFIED — add DecisionsExportDir field + viper binding
+├── organizer/
+│   └── organizer.go     # MODIFIED — call export after CreateDecisionsTab
+└── docs/
+    └── service.go       # READ ONLY — reuse buildDecisionsContent() pattern
+
+cmd/gcal-organizer/
+└── main.go              # MODIFIED — pass config to organizer for export dir
+
+pkg/models/
+└── models.go            # READ ONLY — reuse Decision, CalendarEvent, Attendee types
+```
+
+**Structure Decision**: New `internal/export` package follows the existing pattern of domain-specific packages (`internal/docs`, `internal/drive`, `internal/gemini`). The export logic is isolated from Google API concerns, making it independently testable. No new top-level directories needed.
+
+## Complexity Tracking
+
+> No violations to justify. All gates pass cleanly.
+
+| Violation | Why Needed | Simpler Alternative Rejected Because |
+|-----------|------------|-------------------------------------|
+| (none) | — | — |

--- a/specs/012-decision-markdown-export/quickstart.md
+++ b/specs/012-decision-markdown-export/quickstart.md
@@ -1,0 +1,143 @@
+# Quickstart: Decision Markdown Export
+
+**Feature**: `012-decision-markdown-export` | **Date**: 2026-04-19
+
+## Prerequisites
+
+- Go 1.24+ installed
+- `gcal-organizer` built and configured (OAuth2 credentials, Gemini API key)
+- Calendar events with transcript-bearing attachments (for end-to-end testing)
+
+## Build & Test
+
+```bash
+# Build
+go build ./...
+
+# Run all tests
+go test -race ./...
+
+# Run only export package tests
+go test -v ./internal/export/...
+
+# Run full CI checks
+make ci
+```
+
+## Verify the Feature
+
+### 1. Check default configuration
+
+After implementation, the default export directory should be `~/.gcal-organizer/decisions/`:
+
+```bash
+# Verify the config shows the new field
+gcal-organizer config show
+# Should include: decisions_export_dir: ~/.gcal-organizer/decisions/
+```
+
+### 2. Dry-run to see what would be exported
+
+```bash
+gcal-organizer run --dry-run --verbose
+```
+
+**Expected output** (among other dry-run messages):
+```
+Would export decisions to ~/.gcal-organizer/decisions/weekly-engineering-sync-2026-04-18.md
+```
+
+### 3. Full run to produce actual files
+
+```bash
+gcal-organizer run --verbose
+```
+
+**Expected output**:
+```
+Exported decisions to ~/.gcal-organizer/decisions/weekly-engineering-sync-2026-04-18.md
+```
+
+### 4. Verify the exported file
+
+```bash
+cat ~/.gcal-organizer/decisions/weekly-engineering-sync-2026-04-18.md
+```
+
+**Expected structure**:
+```markdown
+---
+topic: Weekly Engineering Sync
+date: "2026-04-18"
+attendees:
+  - alice@example.com
+  - bob@example.com
+---
+
+## Decisions Made
+
+- Team will adopt GitHub Actions for CI/CD
+
+## Open Items
+
+- Whether to migrate to new API version
+```
+
+### 5. Custom export directory
+
+Set a custom directory via environment variable:
+
+```bash
+export GCAL_DECISIONS_EXPORT_DIR=~/Documents/meeting-decisions
+gcal-organizer run --verbose
+ls ~/Documents/meeting-decisions/
+```
+
+Or via config file (`~/.gcal-organizer/.env`):
+
+```
+GCAL_DECISIONS_EXPORT_DIR=~/Documents/meeting-decisions
+```
+
+### 6. Verify idempotent reprocessing
+
+Run the command again for the same calendar period:
+
+```bash
+gcal-organizer run --verbose --days 1
+```
+
+**Expected**: The Google Docs step logs "Document already has Decisions tab, skipping" (existing behavior). The markdown file is **not** re-exported because the organizer skips the entire extraction when the Decisions tab already exists.
+
+### 7. Verify error resilience
+
+Make the export directory read-only to test FR-012:
+
+```bash
+mkdir -p /tmp/readonly-decisions
+chmod 444 /tmp/readonly-decisions
+GCAL_DECISIONS_EXPORT_DIR=/tmp/readonly-decisions gcal-organizer run --verbose
+```
+
+**Expected**: Warning logged about failed markdown export. Google Docs Decisions tab still created successfully. Pipeline continues.
+
+```bash
+# Cleanup
+chmod 755 /tmp/readonly-decisions
+rm -rf /tmp/readonly-decisions
+```
+
+## Verification Checklist
+
+- [ ] `go build ./...` succeeds
+- [ ] `go test -race ./...` passes
+- [ ] `make ci` passes
+- [ ] `gcal-organizer config show` displays `decisions_export_dir`
+- [ ] `--dry-run` logs "Would export" without creating files
+- [ ] Full run creates markdown files in the configured directory
+- [ ] Exported files have valid YAML frontmatter
+- [ ] Exported files have correct section headings and bullet items
+- [ ] Empty categories are omitted from exported files
+- [ ] Custom export directory works via env var and config file
+- [ ] Export failure does not block Google Docs tab creation
+- [ ] Filename uses kebab-case topic slug + ISO date

--- a/specs/012-decision-markdown-export/research.md
+++ b/specs/012-decision-markdown-export/research.md
@@ -1,0 +1,129 @@
+# Research: Decision Markdown Export
+
+**Feature**: `012-decision-markdown-export` | **Date**: 2026-04-19
+
+## Research Questions
+
+### RQ-1: How does the existing decision extraction pipeline work, and where should the export hook be inserted?
+
+**Finding**: The pipeline flows through these stages:
+
+1. **Collection** (`organizer.SyncCalendarAttachments`): Calendar events are scanned. Attachments titled "Notes by Gemini" or ending with "- Transcript" are collected into `o.decisionDocIDs` (a `map[string]string` of docID→source).
+
+2. **Orchestration** (`cmd/gcal-organizer/main.go`, Step 4): Iterates over `decisionDocIDs`, calling `org.ExtractDecisionsForDoc()` for each.
+
+3. **Extraction** (`organizer.ExtractDecisionsForDoc`): For each document:
+   - Checks for existing Decisions tab (idempotency)
+   - Extracts transcript content via `docsSvc.ExtractTranscriptContent()`
+   - Calls `geminiSvc.ExtractDecisions()` to get `[]models.Decision`
+   - Calls `docsSvc.CreateDecisionsTab()` to write to Google Docs
+   - Updates stats
+
+**Hook point**: The markdown export should be called inside `ExtractDecisionsForDoc()`, **after** the Gemini extraction succeeds and **before or after** `CreateDecisionsTab()`. Placing it after `CreateDecisionsTab()` ensures the Google Docs write (the primary output) is not delayed by local I/O. Per FR-012, local export failure must not block the Docs tab creation, so the export call should be independent — a failure is logged as a warning but does not return an error.
+
+**Decision**: Insert the export call after `CreateDecisionsTab()` succeeds. If the Docs tab creation fails, no local export is attempted (the decisions are considered "not processed"). If the Docs tab succeeds but local export fails, log a warning and continue.
+
+### RQ-2: What metadata is available for YAML frontmatter at the export hook point?
+
+**Finding**: At the point where `ExtractDecisionsForDoc` runs, the available data is:
+- `docID` (string) — the Google Doc ID
+- `decisions` (`[]models.Decision`) — extracted decisions with category, text, timestamp, context
+- `transcript` (`*models.TranscriptContent`) — full text and headings
+
+**Missing at this point**:
+- **Meeting topic/title** — The calendar event title is known during `SyncCalendarAttachments` but is not passed through to `ExtractDecisionsForDoc`. The `decisionDocIDs` map only stores `docID→source`.
+- **Meeting date** — Similarly, the event's `Start` time is available during calendar sync but not threaded through.
+- **Attendees** — The `CalendarEvent.Attendees` list is available during calendar sync but not passed to the decision extraction step.
+
+**Decision**: Enrich the `decisionDocIDs` map to carry meeting metadata alongside the doc ID. Instead of `map[string]string` (docID→source), use a new struct `DecisionDocContext` that includes `Source`, `EventTitle`, `EventDate`, and `Attendees`. This keeps the change localized to the organizer package without requiring new API calls.
+
+### RQ-3: How should the topic slug be derived from the meeting title?
+
+**Finding**: The spec requires (FR-013, FR-014):
+- Strip common suffixes: "- Transcript"
+- Strip common prefixes: "Notes by Gemini"
+- Convert to kebab-case
+- Replace filename-unsafe characters with hyphens
+- Collapse consecutive hyphens
+
+**Existing patterns**: The codebase already parses meeting names from filenames in `drive.ListMeetingDocuments()` using a regex pattern. However, the topic slug for export files is derived from the **calendar event title**, not the document filename.
+
+**Decision**: Create a `slug.go` file in the `internal/export` package with a `TopicSlug(title string) string` function that:
+1. Strips known prefixes/suffixes (case-insensitive)
+2. Converts to lowercase
+3. Replaces non-alphanumeric characters (except hyphens) with hyphens
+4. Collapses consecutive hyphens
+5. Trims leading/trailing hyphens
+
+This is a pure function with no external dependencies, easily tested with table-driven tests.
+
+### RQ-4: How should the markdown file be rendered?
+
+**Finding**: The spec requires (FR-003, FR-004, FR-005, FR-015):
+- YAML frontmatter with `topic`, `date`, and optionally `attendees`
+- Three sections: "Decisions Made", "Decisions Deferred", "Open Items" (level-2 headings)
+- Each decision as a bullet point
+- Empty categories omitted (FR-015)
+
+**Existing pattern**: `docs.buildDecisionsContent()` already constructs content lines with the same three categories. However, it includes "No decisions identified" for empty categories (for the Google Docs tab). The markdown export should **omit** empty categories entirely per FR-015.
+
+**Decision**: The `internal/export` package will have its own rendering function that takes `[]models.Decision` and metadata, and produces a `[]byte` markdown output. It will reuse the same category names and ordering as `buildDecisionsContent()` but with markdown-specific formatting and the FR-015 omission rule. This avoids coupling to the Docs-specific rendering.
+
+### RQ-5: How should the export directory configuration work?
+
+**Finding**: The existing config system uses:
+- `config.Config` struct with fields
+- `viper` for environment variable binding and config file loading
+- `config.DefaultConfig()` for defaults
+- Pattern: `mustBindEnv("key", "ENV_VAR")` + `if v := viper.GetString("key"); v != "" { cfg.Field = v }`
+
+**Decision**: Add a `DecisionsExportDir` field to `config.Config` with default `~/.gcal-organizer/decisions/`. Bind to `GCAL_DECISIONS_EXPORT_DIR` environment variable. The `~` expansion is already handled by the application for other paths (e.g., `CredentialsFile`, `TokenFile`). Follow the exact same pattern.
+
+### RQ-6: How should `--dry-run` interact with the export?
+
+**Finding**: The `dryRun` flag is already threaded through `ExtractDecisionsForDoc` as a parameter. When `dryRun` is true, the method logs "Would extract decisions" and returns early **before** calling Gemini or creating the Docs tab.
+
+**Problem**: In dry-run mode, decisions are never extracted (Gemini is not called), so there's nothing to export. The dry-run log message should indicate that markdown export would also happen.
+
+**Decision**: In dry-run mode, add a log line like "Would export decisions to <path>" alongside the existing "Would extract decisions" message. No file is written. This matches the existing dry-run pattern.
+
+### RQ-7: What about the `--dry-run` case where decisions ARE extracted but we just don't want to write?
+
+**Finding**: Re-reading the spec more carefully — FR-011 says "The `--dry-run` flag MUST suppress markdown file creation and log what would have been written." This implies decisions might be extracted (Gemini called) but the file write is suppressed.
+
+However, the current implementation skips Gemini entirely in dry-run mode. The export dry-run behavior should match: if the organizer skips Gemini in dry-run, the export is also skipped with a "would export" message.
+
+**Decision**: The export function receives a `dryRun` parameter. When true, it logs the file path that would be written and returns without writing. The organizer passes its own dry-run state to the exporter.
+
+### RQ-8: How should the exporter be made testable?
+
+**Finding**: The export function writes to the filesystem. For unit tests, we need to avoid actual filesystem writes.
+
+**Options considered**:
+1. **`afero` filesystem abstraction** — Already an indirect dependency (`github.com/spf13/afero`). Provides `afero.Fs` interface with `afero.MemMapFs` for testing.
+2. **`io/fs` + custom writer** — Standard library, but `io/fs` is read-only. Would need a custom `WriteFS` interface.
+3. **Inject `func(path string, data []byte, perm os.FileMode) error`** — Simple function injection.
+
+**Decision**: Use option 3 — inject a `WriteFile` function. This is the simplest approach that satisfies testability without adding a new dependency or coupling to afero's API. The production code uses `os.WriteFile`; tests inject a mock. The `MkdirAll` function is similarly injectable.
+
+```go
+type Exporter struct {
+    writeFile func(name string, data []byte, perm os.FileMode) error
+    mkdirAll  func(path string, perm os.FileMode) error
+    logger    *log.Logger
+}
+```
+
+This follows the project's existing pattern of dependency injection (e.g., `organizer.New(cfg, driveSvc, calSvc)`).
+
+## Summary of Decisions
+
+| # | Decision | Rationale |
+|---|----------|-----------|
+| D1 | Hook export after `CreateDecisionsTab()` in `ExtractDecisionsForDoc` | Primary output (Docs) completes first; local export failure doesn't block |
+| D2 | Enrich `decisionDocIDs` to carry event metadata (title, date, attendees) | Avoids extra API calls; metadata already available during calendar sync |
+| D3 | New `internal/export` package with `slug.go` + `export.go` | Separation of concerns; independently testable; follows existing package pattern |
+| D4 | Inject `writeFile`/`mkdirAll` functions for testability | Simplest DI approach; no new dependencies; matches project patterns |
+| D5 | Omit empty categories in markdown (FR-015) vs. Docs "No decisions identified" | Spec explicitly requires omission; different rendering rules for different outputs |
+| D6 | Config key `decisions_export_dir` with default `~/.gcal-organizer/decisions/` | Follows existing config pattern; viper binding + env var |
+| D7 | Dry-run logs "would export" without writing | Matches existing dry-run behavior throughout the pipeline |

--- a/specs/012-decision-markdown-export/spec.md
+++ b/specs/012-decision-markdown-export/spec.md
@@ -1,0 +1,116 @@
+# Feature Specification: Decision Markdown Export
+
+**Feature Branch**: `012-decision-markdown-export`
+**Created**: 2026-04-19
+**Status**: Draft
+**Input**: GitHub Issue #12 — Export extracted decisions as local markdown for Dewey indexing
+
+## Overview
+
+gcal-organizer extracts structured decisions from meeting transcripts using Gemini AI and writes them to a "Decisions" tab in Google Docs. These decisions contain valuable project context — what was decided, what was deferred, and what remains open — but they are locked in Google Docs and not discoverable by AI agents or semantic search tools.
+
+This feature adds a local markdown export step to the existing decision extraction pipeline. After writing decisions to Google Docs, the system also writes a markdown copy to a local directory. Each file uses YAML frontmatter and standard markdown headings, making it natively indexable by tools like Dewey for cross-repo semantic search.
+
+The design follows a zero-coupling composability principle: gcal-organizer writes files; external tools read files. No API dependency exists between them.
+
+## User Scenarios & Testing *(mandatory)*
+
+### User Story 1 - Export Decisions as Local Markdown (Priority: P1)
+
+As a meeting organizer who uses gcal-organizer, I want meeting decisions automatically saved as local markdown files so that they are available for offline reference and discoverable by AI-powered search tools without opening Google Docs.
+
+**Why this priority**: This is the core value proposition. Without local file export, decisions remain locked in Google Docs. Writing a markdown file is the minimum viable increment that unlocks all downstream use cases (semantic search, team knowledge sharing, offline access).
+
+**Independent Test**: Can be fully tested by running `gcal-organizer run` against a calendar with transcript-bearing events and verifying that markdown files appear in the configured output directory with correct content and structure.
+
+**Acceptance Scenarios**:
+
+1. **Given** a calendar event with a transcript that contains extractable decisions, **When** the user runs the standard `gcal-organizer run` command, **Then** a markdown file is created in the decisions output directory containing the same decisions that were written to the Google Docs "Decisions" tab.
+2. **Given** the decisions output directory does not yet exist, **When** decision export runs for the first time, **Then** the directory is created automatically and the file is written successfully.
+3. **Given** a markdown file already exists for the same meeting topic and date, **When** the transcript is reprocessed, **Then** the existing file is overwritten with the updated decisions (idempotent behavior).
+4. **Given** the `--dry-run` flag is set, **When** decision extraction runs, **Then** no markdown files are written to disk and the user sees a message indicating what would have been exported.
+
+---
+
+### User Story 2 - Configure Export Directory (Priority: P2)
+
+As a user who manages multiple machines or has a preferred file organization, I want to configure where decision markdown files are saved so that I can control the output location to suit my environment.
+
+**Why this priority**: A configurable output path allows users to point the export at a Dewey-indexed directory, a shared folder, or any location that fits their workflow. Without this, the feature works but with a fixed path that may not suit all users.
+
+**Independent Test**: Can be tested by setting the configuration value to a custom path and verifying files are written to that location instead of the default.
+
+**Acceptance Scenarios**:
+
+1. **Given** no export directory is configured, **When** decisions are exported, **Then** files are written to the default directory (`~/.gcal-organizer/decisions/`).
+2. **Given** the user has configured a custom export directory, **When** decisions are exported, **Then** files are written to the configured directory.
+3. **Given** the configured directory path uses a home directory shorthand (`~`), **When** decisions are exported, **Then** the path is expanded correctly and files are written to the resolved location.
+
+---
+
+### User Story 3 - Include Meeting Metadata in Frontmatter (Priority: P3)
+
+As a user who searches across decision files, I want each markdown file to include structured metadata (date, topic, attendees) in YAML frontmatter so that search tools can filter and rank results by meeting context.
+
+**Why this priority**: Frontmatter enriches the exported files with queryable metadata. Without it, the files still contain decisions (US1 delivers value), but search and filtering capabilities are limited.
+
+**Independent Test**: Can be tested by exporting a decision file and verifying the YAML frontmatter contains the correct date, topic, and attendee list parsed from the calendar event.
+
+**Acceptance Scenarios**:
+
+1. **Given** a calendar event with attendees and a meeting title, **When** decisions are exported, **Then** the markdown file includes YAML frontmatter with `topic`, `date`, and `attendees` fields.
+2. **Given** a calendar event with no attendees listed, **When** decisions are exported, **Then** the frontmatter includes `topic` and `date` but omits the `attendees` field rather than writing an empty list.
+3. **Given** a meeting title contains the suffix "- Transcript" or is prefixed with "Notes by Gemini", **When** the topic is derived, **Then** these suffixes/prefixes are stripped to produce a clean topic name.
+
+---
+
+### Edge Cases
+
+- What happens when the export directory path is invalid or the filesystem is read-only? The system logs a warning and continues processing (decision extraction to Google Docs still succeeds; local export failure does not block the pipeline).
+- What happens when the meeting title contains characters that are invalid in filenames (e.g., `/`, `\`, `:`)? Invalid filename characters are replaced with hyphens to produce a safe filename.
+- What happens when two calendar events on the same date produce the same derived topic name? The second file overwrites the first (last-write-wins). This is acceptable because decisions from the same topic on the same date represent the same meeting context.
+- What happens when Gemini returns zero decisions for a transcript? No markdown file is created. Only meetings with at least one extracted decision produce an export file.
+- What happens when the user has disabled decision extraction entirely? No markdown files are produced. The export step is skipped along with the rest of decision processing.
+
+## Requirements *(mandatory)*
+
+### Functional Requirements
+
+- **FR-001**: System MUST write a markdown file to the decisions output directory for each meeting that produces at least one extracted decision.
+- **FR-002**: Each exported markdown file MUST use the naming convention `<topic-slug>-<YYYY-MM-DD>.md`, where `topic-slug` is a kebab-case version of the meeting topic and `YYYY-MM-DD` is the meeting date.
+- **FR-003**: Each exported markdown file MUST contain three sections matching the existing decision categories: "Decisions Made", "Decisions Deferred", and "Open Items", using level-2 markdown headings.
+- **FR-004**: Each decision item MUST be rendered as a markdown bullet point under its category heading.
+- **FR-005**: Each exported markdown file MUST include YAML frontmatter with at minimum `topic` (string) and `date` (ISO 8601 date string) fields.
+- **FR-006**: The frontmatter SHOULD include an `attendees` field (list of strings) when attendee information is available from the calendar event. The field is omitted when no attendees are available.
+- **FR-007**: The system MUST create the output directory (including parent directories) if it does not exist when the first file is exported.
+- **FR-008**: If a file with the same name already exists in the output directory, the system MUST overwrite it (idempotent reprocessing).
+- **FR-009**: The default output directory MUST be `~/.gcal-organizer/decisions/`.
+- **FR-010**: The output directory MUST be configurable via the existing configuration mechanism (configuration file).
+- **FR-011**: The `--dry-run` flag MUST suppress markdown file creation and log what would have been written.
+- **FR-012**: If the markdown file cannot be written (permissions error, disk full, invalid path), the system MUST log a warning and continue processing remaining events. The failure of local export MUST NOT prevent the Google Docs "Decisions" tab from being created.
+- **FR-013**: The meeting topic MUST be derived from the calendar event title, with common suffixes ("- Transcript") and prefixes ("Notes by Gemini") stripped.
+- **FR-014**: Filename-unsafe characters in the topic slug MUST be replaced with hyphens, and consecutive hyphens MUST be collapsed to a single hyphen.
+- **FR-015**: Empty decision categories MUST be omitted from the exported file rather than rendered as empty sections.
+
+### Key Entities
+
+- **Decision Export File**: A markdown file representing all decisions extracted from a single meeting. Contains YAML frontmatter (topic, date, attendees) and categorized decision content (made, deferred, open items). Named by topic slug and date.
+- **Export Configuration**: The output directory path for decision files. Stored in the existing application configuration. Defaults to `~/.gcal-organizer/decisions/`.
+
+## Success Criteria *(mandatory)*
+
+### Measurable Outcomes
+
+- **SC-001**: Every meeting that produces decisions via Gemini extraction also produces a corresponding local markdown file (100% parity with Google Docs export, unless local write fails).
+- **SC-002**: Exported markdown files are valid markdown with parseable YAML frontmatter, verifiable by standard markdown linting tools.
+- **SC-003**: Reprocessing a meeting that was previously exported overwrites the existing file without creating duplicates, producing exactly one file per topic-date combination.
+- **SC-004**: A user can configure a custom export directory and see files appear at that location on the next run, with zero files at the old location for newly processed meetings.
+- **SC-005**: Local export failures (permission errors, disk issues) do not prevent the rest of the pipeline from completing successfully, including the Google Docs Decisions tab creation.
+
+## Assumptions
+
+- The meeting topic can be reliably derived from the calendar event title. Calendar events processed by gcal-organizer have titles set by Google Calendar, which are typically descriptive meeting names.
+- Attendee information is available from the Calendar API response for events the user owns. For events the user is an attendee of (not the organizer), attendee lists may be restricted by organizational policies.
+- The existing configuration mechanism (viper/config file) supports adding new configuration keys without breaking existing configurations.
+- The home directory shorthand (`~`) is expanded by the application, consistent with how the existing `~/.gcal-organizer/` paths are handled.
+- Users who want Dewey indexing will separately configure their Dewey sources to point at the decisions directory. This feature does not modify Dewey configuration.

--- a/specs/012-decision-markdown-export/tasks.md
+++ b/specs/012-decision-markdown-export/tasks.md
@@ -1,0 +1,205 @@
+# Tasks: Decision Markdown Export
+
+**Input**: Design documents from `/specs/012-decision-markdown-export/`
+**Prerequisites**: plan.md (required), spec.md (required), research.md, data-model.md, quickstart.md
+
+**Organization**: Tasks are grouped by user story to enable independent implementation and testing of each story.
+
+## Format: `[ID] [P?] [Story] Description`
+
+- **[P]**: Can run in parallel (different files, no dependencies)
+- **[Story]**: Which user story this task belongs to (e.g., US1, US2, US3)
+- Include exact file paths in descriptions
+
+---
+
+## Phase 1: Setup (Shared Infrastructure)
+
+**Purpose**: Create the new `internal/export` package and establish the project structure for this feature.
+
+- [x] T001 Create `internal/export/` package directory with `export.go` stub (package declaration, GoDoc comment, imports placeholder)
+- [x] T002 [P] Create `internal/export/slug.go` stub (package declaration, GoDoc comment)
+- [x] T003 [P] Create `internal/export/export_test.go` stub (package declaration, test imports)
+- [x] T004 [P] Create `internal/export/slug_test.go` stub (package declaration, test imports)
+
+---
+
+## Phase 2: Foundational (Blocking Prerequisites)
+
+**Purpose**: Core data model changes and slug generation that ALL user stories depend on. These modify shared types and provide the filename generation logic used by every export operation.
+
+**CRITICAL**: No user story work can begin until this phase is complete.
+
+- [x] T005 Add `DecisionDocContext` struct to `internal/organizer/organizer.go` with fields: `DocID string`, `Source string`, `EventTitle string`, `EventDate time.Time`, `Attendees []string` (per data-model.md entity definition)
+- [x] T006 Refactor `Organizer.decisionDocIDs` field from `map[string]string` to `map[string]DecisionDocContext` in `internal/organizer/organizer.go` and update `New()` initializer
+- [x] T007 Refactor `GetDecisionDocIDs()` to `GetDecisionDocContexts()` returning `map[string]DecisionDocContext` in `internal/organizer/organizer.go`
+- [x] T008 Update `SyncCalendarAttachments()` in `internal/organizer/organizer.go` to populate `DecisionDocContext` with `EventTitle`, `EventDate`, and `Attendees` (filtering out self and resource attendees) instead of plain string source
+- [x] T009 Update Step 4 loop in `cmd/gcal-organizer/main.go` to call `GetDecisionDocContexts()` instead of `GetDecisionDocIDs()` and pass `DecisionDocContext` to `ExtractDecisionsForDoc()`
+- [x] T010 Update `ExtractDecisionsForDoc()` signature in `internal/organizer/organizer.go` to accept `DecisionDocContext` instead of bare `docID string` (extract `docID` from context struct internally)
+- [x] T011 Implement `TopicSlug(title string) string` function in `internal/export/slug.go` per slug generation rules in data-model.md: strip prefixes ("Notes by Gemini"), strip suffixes ("- Transcript"), lowercase, replace non-alphanumeric with hyphens, collapse consecutive hyphens, trim, fallback to "meeting" for empty result
+- [x] T012 [P] Write table-driven tests for `TopicSlug()` in `internal/export/slug_test.go` covering all examples from data-model.md: "Weekly Engineering Sync", "Notes by Gemini", "Project Alpha - Transcript", "Q3 Budget / Planning", "Design Review: API v2", empty string
+
+**Checkpoint**: Foundation ready — `DecisionDocContext` flows through the pipeline, slug generation works. User story implementation can now begin.
+
+---
+
+## Phase 3: User Story 1 — Export Decisions as Local Markdown (Priority: P1)
+
+**Goal**: After writing decisions to Google Docs, also write a markdown copy to `~/.gcal-organizer/decisions/` with correct content structure (three category sections as bullet lists). This is the core value proposition — unlocking decisions from Google Docs into local files.
+
+**Independent Test**: Run `gcal-organizer run` against a calendar with transcript-bearing events and verify markdown files appear in `~/.gcal-organizer/decisions/` with correct content matching the Google Docs Decisions tab.
+
+### Implementation for User Story 1
+
+- [x] T013 [US1] Define `Exporter` struct in `internal/export/export.go` with injectable dependencies: `writeFile func(string, []byte, os.FileMode) error`, `mkdirAll func(string, os.FileMode) error`, `logger *log.Logger`, `outputDir string` (per research.md D4)
+- [x] T014 [US1] Implement `NewExporter(outputDir string, logger *log.Logger) *Exporter` constructor in `internal/export/export.go` that defaults `writeFile` to `os.WriteFile` and `mkdirAll` to `os.MkdirAll`
+- [x] T015 [US1] Implement `renderMarkdown(decisions []models.Decision, topic string, date time.Time, attendees []string) []byte` internal function in `internal/export/export.go` that produces YAML frontmatter (`topic`, `date`) and three category sections (`## Decisions Made`, `## Decisions Deferred`, `## Open Items`) with bullet items, omitting empty categories (FR-015)
+- [x] T016 [US1] Implement `Exporter.Export(ctx context.Context, decisions []models.Decision, meta DecisionDocContext, dryRun bool) error` method in `internal/export/export.go`: generate filename via `TopicSlug(meta.EventTitle)` + date, call `mkdirAll` for output dir (FR-007), call `writeFile` with rendered markdown (FR-001, FR-008), log warning on write failure without returning error (FR-012)
+- [x] T017 [US1] Implement dry-run behavior in `Exporter.Export()`: when `dryRun` is true, log "Would export decisions to <path>" and return nil without writing (FR-011, research.md D7)
+- [x] T018 [US1] Add export hook in `ExtractDecisionsForDoc()` in `internal/organizer/organizer.go`: after successful `CreateDecisionsTab()`, call `exporter.Export()` passing decisions and `DecisionDocContext`; log warning on failure but do not return error (FR-012, research.md D1)
+- [x] T019 [US1] Wire `Exporter` creation in `cmd/gcal-organizer/main.go`: create `export.NewExporter()` with default output dir (`~/.gcal-organizer/decisions/`) before the Step 4 loop, pass to `ExtractDecisionsForDoc()` or set on Organizer
+- [x] T020 [US1] Add `DecisionsExported int` and `DecisionsExportFailed int` fields to `Stats` struct in `internal/organizer/organizer.go` and increment them in the export hook
+- [x] T021 [US1] Update `printSummary()` in `internal/organizer/organizer.go` to display export stats (`decisions_exported`, `decisions_export_failed`) when non-zero
+- [x] T022 [US1] Write table-driven tests for `renderMarkdown()` in `internal/export/export_test.go`: all three categories populated, single category only, empty categories omitted, decisions with special characters
+- [x] T023 [US1] Write tests for `Exporter.Export()` in `internal/export/export_test.go` using injected mock `writeFile`/`mkdirAll`: successful write, directory creation, overwrite existing file (FR-008), write failure logs warning (FR-012), dry-run suppresses write (FR-011)
+- [x] T024 [US1] Write test for zero-decisions case in `internal/export/export_test.go`: verify no file is created when `decisions` slice is empty (edge case from spec)
+- [x] T024b [US1] Write integration test for `ExtractDecisionsForDoc()` in `internal/organizer/` verifying that the exporter is called after `CreateDecisionsTab()` succeeds, and that export failure does not cause `ExtractDecisionsForDoc()` to return an error (FR-012)
+
+**Checkpoint**: At this point, User Story 1 should be fully functional — `gcal-organizer run` produces markdown files in the default directory with correct content structure.
+
+---
+
+## Phase 4: User Story 2 — Configure Export Directory (Priority: P2)
+
+**Goal**: Allow users to configure where decision markdown files are saved via the config file or `GCAL_DECISIONS_EXPORT_DIR` environment variable, defaulting to `~/.gcal-organizer/decisions/`.
+
+**Independent Test**: Set `GCAL_DECISIONS_EXPORT_DIR=~/Documents/meeting-decisions`, run `gcal-organizer run`, and verify files appear at the custom location.
+
+### Implementation for User Story 2
+
+- [x] T025 [US2] Add `DecisionsExportDir string` field to `Config` struct in `internal/config/config.go` with default `~/.gcal-organizer/decisions/` set in `DefaultConfig()`
+- [x] T026 [US2] Add `mustBindEnv("decisions_export_dir", "GCAL_DECISIONS_EXPORT_DIR")` and viper override in `Load()` in `internal/config/config.go`, following the existing pattern for other config keys
+- [x] T027 [US2] Add tilde (`~`) expansion for `DecisionsExportDir` in `Load()` in `internal/config/config.go`, consistent with how `CredentialsFile` and `TokenFile` paths are handled
+- [x] T028 [US2] Update `Exporter` creation in `cmd/gcal-organizer/main.go` to use `cfg.DecisionsExportDir` instead of hardcoded default path
+- [x] T029 [US2] Write test in `internal/config/config_test.go` (or appropriate test file) verifying `DefaultConfig()` sets `DecisionsExportDir` to `~/.gcal-organizer/decisions/`
+- [x] T030 [US2] Write test for tilde expansion of `DecisionsExportDir` verifying `~/foo` resolves to an absolute path
+
+**Checkpoint**: At this point, User Stories 1 AND 2 should both work — files are written to the configured directory (or default if unconfigured).
+
+---
+
+## Phase 5: User Story 3 — Include Meeting Metadata in Frontmatter (Priority: P3)
+
+**Goal**: Enrich exported markdown files with YAML frontmatter containing `attendees` list from the calendar event, enabling search tools to filter by meeting participants.
+
+**Independent Test**: Export a decision file and verify the YAML frontmatter contains the correct `attendees` list parsed from the calendar event. Verify `attendees` is omitted when no attendees are available.
+
+### Implementation for User Story 3
+
+- [x] T031 [US3] Update `renderMarkdown()` in `internal/export/export.go` to include `attendees` field in YAML frontmatter when the attendees slice is non-empty (FR-006); omit the field entirely when empty
+- [x] T032 [US3] Implement topic cleaning in `renderMarkdown()` or a helper in `internal/export/slug.go`: strip "- Transcript" suffix and "Notes by Gemini" prefix from the topic used in frontmatter (FR-013), distinct from the slug used in filenames
+- [x] T033 [US3] Write tests in `internal/export/export_test.go` for frontmatter with attendees: verify YAML `attendees` list renders correctly with multiple attendees
+- [x] T034 [US3] Write test in `internal/export/export_test.go` for frontmatter without attendees: verify `attendees` field is omitted (not an empty list) when attendees slice is empty
+- [x] T035 [US3] Write test in `internal/export/export_test.go` for topic cleaning: verify "Weekly Sync - Transcript" produces frontmatter `topic: Weekly Sync` and "Notes by Gemini - Project Alpha" produces `topic: Project Alpha`
+
+**Checkpoint**: All user stories should now be independently functional — exported files have full metadata, configurable output, and correct content.
+
+---
+
+## Phase 6: Polish & Cross-Cutting Concerns
+
+**Purpose**: Documentation, summary reporting, and validation across all stories.
+
+- [x] T036 [P] Update dry-run summary in `printSummary()` in `internal/organizer/organizer.go` to include "Would export decisions" count alongside existing dry-run stats
+- [x] T037 [P] Add `decisions_export_dir` to `config show` output if a config show command exists (check `cmd/gcal-organizer/auth_config.go` or equivalent)
+- [x] T038 Run `go build ./...` to verify compilation succeeds with all changes
+- [x] T039 Run `go test -race ./...` to verify all tests pass with race detector
+- [x] T040 Run `go vet ./...` to verify no vet warnings
+- [x] T041 Run `make ci` to verify full CI parity (per AGENTS.md CI Parity Gate)
+- [ ] T042 Run quickstart.md verification checklist: dry-run output, full run file creation, YAML frontmatter validity, empty category omission, custom export directory, error resilience
+- [x] T043 Update README.md to document the `decisions_export_dir` configuration option, the decision markdown export behavior, and the `GCAL_DECISIONS_EXPORT_DIR` environment variable
+
+---
+
+## Dependencies & Execution Order
+
+### Phase Dependencies
+
+- **Setup (Phase 1)**: No dependencies — can start immediately
+- **Foundational (Phase 2)**: Depends on Phase 1 completion — BLOCKS all user stories
+- **User Stories (Phases 3–5)**: All depend on Phase 2 completion
+  - US1 (Phase 3) must complete before US2 (Phase 4) — US2 modifies how the exporter is created
+  - US3 (Phase 5) can start after Phase 2 but integrates with US1's `renderMarkdown()`
+  - Recommended order: US1 → US2 → US3 (sequential by priority)
+- **Polish (Phase 6)**: Depends on all user stories being complete
+
+### User Story Dependencies
+
+- **User Story 1 (P1)**: Can start after Phase 2. Creates the `Exporter`, `renderMarkdown()`, and the pipeline hook. All other stories build on this.
+- **User Story 2 (P2)**: Depends on US1 (T019 creates the exporter with a hardcoded path; T028 replaces it with config). Can be implemented immediately after US1.
+- **User Story 3 (P3)**: Depends on US1 (T015 creates `renderMarkdown()`; T031 extends it with attendees). Can be implemented after US1.
+
+### Within Each User Story
+
+- Struct/type definitions before method implementations
+- Core logic before integration hooks
+- Implementation before tests (tests validate the implementation)
+- Pipeline wiring (main.go, organizer.go hooks) after core logic
+
+### Parallel Opportunities
+
+- Phase 1: T002, T003, T004 can run in parallel with each other (after T001)
+- Phase 2: T011 and T012 (slug) can run in parallel with T005–T010 (data model refactor) since they touch different files
+- Phase 6: T036 and T037 can run in parallel (different files)
+
+---
+
+## Parallel Example: Phase 2 (Foundational)
+
+```bash
+# Stream 1: Data model refactor (sequential — same file)
+Task T005: "Add DecisionDocContext struct to internal/organizer/organizer.go"
+Task T006: "Refactor decisionDocIDs to map[string]DecisionDocContext"
+Task T007: "Refactor GetDecisionDocIDs to GetDecisionDocContexts"
+Task T008: "Update SyncCalendarAttachments to populate DecisionDocContext"
+Task T009: "Update Step 4 loop in cmd/gcal-organizer/main.go"
+Task T010: "Update ExtractDecisionsForDoc signature"
+
+# Stream 2: Slug generation (parallel — different files)
+Task T011: "Implement TopicSlug in internal/export/slug.go"
+Task T012: "Write slug tests in internal/export/slug_test.go"
+```
+
+---
+
+## Implementation Strategy
+
+### MVP First (User Story 1 Only)
+
+1. Complete Phase 1: Setup (4 tasks)
+2. Complete Phase 2: Foundational (8 tasks)
+3. Complete Phase 3: User Story 1 (12 tasks)
+4. **STOP and VALIDATE**: Run `go test -race ./...` and verify markdown files are produced
+5. Deploy/demo if ready — decisions are now exported locally
+
+### Incremental Delivery
+
+1. Setup + Foundational -> Foundation ready
+2. Add User Story 1 -> Test independently -> Decisions exported to default dir (MVP!)
+3. Add User Story 2 -> Test independently -> Configurable export directory
+4. Add User Story 3 -> Test independently -> Rich metadata in frontmatter
+5. Polish -> CI validation -> Feature complete
+
+---
+
+## Notes
+
+- [P] tasks = different files, no dependencies
+- [Story] label maps task to specific user story for traceability
+- Each user story should be independently completable and testable
+- Commit after each task or logical group
+- Stop at any checkpoint to validate story independently
+- No new external dependencies — all libraries are already in go.mod
+- FR-012 is the critical resilience requirement: export failure MUST NOT block the pipeline
+<!-- spec-review: passed -->
+<!-- code-review: passed -->


### PR DESCRIPTION
## Summary

- Add local markdown export to the decision extraction pipeline — after writing decisions to a Google Docs "Decisions" tab, also write a markdown copy to `~/.gcal-organizer/decisions/` (configurable)
- Each file has YAML frontmatter (topic, date, attendees) and categorized sections (Decisions Made, Decisions Deferred, Open Items)
- Zero coupling: gcal-organizer writes files; Dewey reads files independently
- Export failures are non-blocking (FR-012) — the Google Docs pipeline continues even if local write fails

## Changes

**New package** `internal/export/`:
- `Exporter` with injectable `writeFile`/`mkdirAll` for testability
- `TopicSlug()` for filename-safe slug generation
- `CleanTopic()` for frontmatter title cleaning
- `renderMarkdown()` for YAML frontmatter + categorized sections

**Modified files:**
- `internal/organizer/organizer.go` — `DecisionExporter` interface, pipeline hook, export stats
- `internal/config/config.go` — `DecisionsExportDir` config with `GCAL_DECISIONS_EXPORT_DIR` env var
- `pkg/models/models.go` — `DecisionDocContext` struct (moved from organizer for clean boundaries)
- `cmd/gcal-organizer/main.go` — wiring
- `README.md` — documentation

## Testing

- 12 test packages pass with `-race -count=1`
- Table-driven tests for slug (13 cases), render (6 cases), export (6 cases), topic cleaning (6 cases)
- Integration tests verifying FR-012 (export failure does not block pipeline)

Closes #12