### PR TITLE
fix: use Drive file name instead of attachment title for shortcuts

### DIFF
--- a/internal/organizer/organizer.go
+++ b/internal/organizer/organizer.go
@@ -396,6 +396,10 @@ func (o *Organizer) SyncCalendarAttachments(ctx context.Context) error {
 	o.stats.EventsProcessed = len(events)
 	o.logger.Info("Found calendar events", "count", len(events), "days", o.config.DaysToLookBack)
 
+	// Cross-event cache for Drive file name lookups to avoid redundant API calls
+	// when the same file ID appears across multiple calendar events.
+	fileNameCache := make(map[string]string)
+
 	for _, event := range events {
 		if len(event.Attachments) == 0 {
 			continue
@@ -436,23 +440,31 @@ func (o *Organizer) SyncCalendarAttachments(ctx context.Context) error {
 				continue
 			}
 
-			title := att.Title
-			if title == "" {
-				// Fetch actual filename from Drive
-				fileName, err := o.drive.GetFileName(ctx, att.FileID)
-				if err != nil {
-					title = fmt.Sprintf("attachment (%s...)", att.FileID[:min(8, len(att.FileID))])
-				} else {
-					title = fileName
-				}
+			// Always prefer the actual Drive file name over the calendar
+			// attachment title. The attachment title can be generic (e.g.,
+			// "Notes by Gemini") while the Drive file has a descriptive name.
+			var title string
+			if cached, ok := fileNameCache[att.FileID]; ok {
+				title = cached
+			} else if fileName, err := o.drive.GetFileName(ctx, att.FileID); err == nil {
+				title = fileName
+				fileNameCache[att.FileID] = fileName
+			} else if att.Title != "" {
+				title = att.Title
+			} else {
+				title = fmt.Sprintf("attachment (%s...)", att.FileID[:min(8, len(att.FileID))])
 			}
 
 			result := o.drive.CreateShortcut(ctx, att.FileID, title, folder.ID, folder.Name, folder.IsNew)
 			o.logCalendarAction(result, event.Title, event.Start.Format("2006-01-02"), title)
 
 			// Track Google Docs with "Notes" in the title for task assignment
+			// Use both the Drive file name and the attachment title for matching,
+			// since either may contain the keyword.
+			titleLower := strings.ToLower(title)
+			attTitleLower := strings.ToLower(att.Title)
 			if att.MimeType == "application/vnd.google-apps.document" &&
-				strings.Contains(strings.ToLower(title), "notes") {
+				(strings.Contains(titleLower, "notes") || strings.Contains(attTitleLower, "notes")) {
 				// When --owned-only is active, only collect owned docs for Step 3
 				if o.config.OwnedOnly {
 					if !isOwned(att.FileID) {
@@ -463,13 +475,13 @@ func (o *Organizer) SyncCalendarAttachments(ctx context.Context) error {
 			}
 
 			// Track Google Docs eligible for decision extraction (Step 4)
-			// Exact match "Notes by Gemini" or suffix "- Transcript"
+			// Use att.Title for classification (reliable pattern) and title for suffix matching
 			if att.MimeType == "application/vnd.google-apps.document" {
-				if title == "Notes by Gemini" {
+				if att.Title == "Notes by Gemini" || strings.HasSuffix(title, "- Notes by Gemini") {
 					// "Notes by Gemini" always wins in per-event deduplication
 					eventDecisionDocID = att.FileID
 					eventDecisionSource = "notes-by-gemini"
-				} else if strings.HasSuffix(title, "- Transcript") && eventDecisionSource != "notes-by-gemini" {
+				} else if (strings.HasSuffix(title, "- Transcript") || strings.HasSuffix(att.Title, "- Transcript")) && eventDecisionSource != "notes-by-gemini" {
 					// Only use transcript if no "Notes by Gemini" found yet for this event
 					eventDecisionDocID = att.FileID
 					eventDecisionSource = "transcript"

--- a/internal/organizer/organizer_test.go
+++ b/internal/organizer/organizer_test.go
@@ -40,6 +40,7 @@ type mockDriveService struct {
 	isFileOwnedErr          map[string]error
 	canEditFileResults      map[string]bool
 	getFileNameResults      map[string]string
+	getFileNameErr          map[string]error
 }
 
 type shortcutCall struct {
@@ -142,6 +143,11 @@ func (m *mockDriveService) CanEditFile(_ context.Context, fileID string) bool {
 
 func (m *mockDriveService) GetFileName(_ context.Context, fileID string) (string, error) {
 	m.getFileNameCalls = append(m.getFileNameCalls, fileID)
+	if m.getFileNameErr != nil {
+		if err, ok := m.getFileNameErr[fileID]; ok {
+			return "", err
+		}
+	}
 	if m.getFileNameResults != nil {
 		if name, ok := m.getFileNameResults[fileID]; ok {
 			return name, nil
@@ -2050,5 +2056,146 @@ func TestExtractDecisionsForDoc_ExportFailureDoesNotBlockPipeline(t *testing.T) 
 	// Contract: decisions still counted as processed
 	if org.stats.DecisionsProcessed != 1 {
 		t.Errorf("DecisionsProcessed: got %d, want 1", org.stats.DecisionsProcessed)
+	}
+}
+
+func TestSyncCalendarAttachments_UsesGetFileNameForShortcut(t *testing.T) {
+	// When att.Title is a generic name like "Notes by Gemini", GetFileName()
+	// should be called and its result used as the shortcut name.
+	driveMock := &mockDriveService{
+		canEditFileResults: map[string]bool{"doc1": false},
+		getFileNameResults: map[string]string{
+			"doc1": "Sprint Planning - 2026/04/11 09:00 EST - Notes by Gemini",
+		},
+	}
+	calMock := &mockCalendarService{
+		listRecentEventsReturn: []*models.CalendarEvent{
+			{
+				ID:    "evt1",
+				Title: "Sprint Planning",
+				Start: time.Date(2026, 4, 11, 9, 0, 0, 0, time.UTC),
+				Attachments: []models.Attachment{
+					{FileID: "doc1", Title: "Notes by Gemini", MimeType: "application/vnd.google-apps.document"},
+				},
+			},
+		},
+	}
+	cfg := config.DefaultConfig()
+	org := setupOrganizer(cfg, driveMock, calMock)
+
+	err := org.SyncCalendarAttachments(context.Background())
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	// Contract: GetFileName was called for the attachment
+	if len(driveMock.getFileNameCalls) != 1 {
+		t.Fatalf("GetFileName calls: got %d, want 1", len(driveMock.getFileNameCalls))
+	}
+	if driveMock.getFileNameCalls[0] != "doc1" {
+		t.Errorf("GetFileName called with %q, want %q", driveMock.getFileNameCalls[0], "doc1")
+	}
+
+	// Contract: CreateShortcut used the Drive file name, not "Notes by Gemini"
+	if len(driveMock.createShortcutCalls) != 1 {
+		t.Fatalf("CreateShortcut calls: got %d, want 1", len(driveMock.createShortcutCalls))
+	}
+	got := driveMock.createShortcutCalls[0].fileName
+	want := "Sprint Planning - 2026/04/11 09:00 EST - Notes by Gemini"
+	if got != want {
+		t.Errorf("CreateShortcut fileName: got %q, want %q", got, want)
+	}
+}
+
+func TestSyncCalendarAttachments_FallsBackToAttTitle(t *testing.T) {
+	// When GetFileName() fails, fall back to att.Title.
+	driveMock := &mockDriveService{
+		canEditFileResults: map[string]bool{"doc1": false},
+		getFileNameErr:     map[string]error{"doc1": fmt.Errorf("permission denied")},
+	}
+	calMock := &mockCalendarService{
+		listRecentEventsReturn: []*models.CalendarEvent{
+			{
+				ID:    "evt1",
+				Title: "Weekly Sync",
+				Start: time.Date(2026, 4, 14, 10, 0, 0, 0, time.UTC),
+				Attachments: []models.Attachment{
+					{FileID: "doc1", Title: "Notes by Gemini", MimeType: "application/vnd.google-apps.document"},
+				},
+			},
+		},
+	}
+	cfg := config.DefaultConfig()
+	org := setupOrganizer(cfg, driveMock, calMock)
+
+	err := org.SyncCalendarAttachments(context.Background())
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	// Contract: GetFileName was called but failed
+	if len(driveMock.getFileNameCalls) != 1 {
+		t.Fatalf("GetFileName calls: got %d, want 1", len(driveMock.getFileNameCalls))
+	}
+
+	// Contract: CreateShortcut used att.Title as fallback
+	if len(driveMock.createShortcutCalls) != 1 {
+		t.Fatalf("CreateShortcut calls: got %d, want 1", len(driveMock.createShortcutCalls))
+	}
+	got := driveMock.createShortcutCalls[0].fileName
+	if got != "Notes by Gemini" {
+		t.Errorf("CreateShortcut fileName: got %q, want %q", got, "Notes by Gemini")
+	}
+}
+
+func TestSyncCalendarAttachments_CachesFileNameLookups(t *testing.T) {
+	// When two events reference the same file ID, GetFileName() is called only once.
+	driveMock := &mockDriveService{
+		canEditFileResults: map[string]bool{"doc1": false},
+		getFileNameResults: map[string]string{
+			"doc1": "Sprint Planning - Notes by Gemini",
+		},
+	}
+	calMock := &mockCalendarService{
+		listRecentEventsReturn: []*models.CalendarEvent{
+			{
+				ID:    "evt1",
+				Title: "Sprint Planning",
+				Start: time.Date(2026, 4, 11, 9, 0, 0, 0, time.UTC),
+				Attachments: []models.Attachment{
+					{FileID: "doc1", Title: "Notes by Gemini", MimeType: "application/vnd.google-apps.document"},
+				},
+			},
+			{
+				ID:    "evt2",
+				Title: "Sprint Planning",
+				Start: time.Date(2026, 4, 18, 9, 0, 0, 0, time.UTC),
+				Attachments: []models.Attachment{
+					{FileID: "doc1", Title: "Notes by Gemini", MimeType: "application/vnd.google-apps.document"},
+				},
+			},
+		},
+	}
+	cfg := config.DefaultConfig()
+	org := setupOrganizer(cfg, driveMock, calMock)
+
+	err := org.SyncCalendarAttachments(context.Background())
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	// Contract: GetFileName called only once despite two events with same file ID
+	if len(driveMock.getFileNameCalls) != 1 {
+		t.Errorf("GetFileName calls: got %d, want 1 (cache should prevent second call)", len(driveMock.getFileNameCalls))
+	}
+
+	// Contract: Both shortcuts used the cached Drive file name
+	if len(driveMock.createShortcutCalls) != 2 {
+		t.Fatalf("CreateShortcut calls: got %d, want 2", len(driveMock.createShortcutCalls))
+	}
+	for i, call := range driveMock.createShortcutCalls {
+		if call.fileName != "Sprint Planning - Notes by Gemini" {
+			t.Errorf("CreateShortcut[%d] fileName: got %q, want %q", i, call.fileName, "Sprint Planning - Notes by Gemini")
+		}
 	}
 }

--- a/openspec/changes/shortcut-drive-filename/.openspec.yaml
+++ b/openspec/changes/shortcut-drive-filename/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-04-20

--- a/openspec/changes/shortcut-drive-filename/design.md
+++ b/openspec/changes/shortcut-drive-filename/design.md
@@ -1,0 +1,40 @@
+## Context
+
+gcal-organizer's Step 2 (`SyncCalendarAttachments`) creates shortcuts in per-meeting folders for each calendar event attachment. The shortcut name is derived from `att.Title` -- the title field from the Calendar API's attachment object. For most attachments this is fine, but for Google's auto-generated "Notes by Gemini" documents, the Calendar API always returns the generic title "Notes by Gemini" even though the actual Drive file has a descriptive name like "Tanya / Joy 1-1 - 2026/02/12 13:55 EST - Notes by Gemini".
+
+The `GetFileName()` Drive API call exists and is already used as a fallback when `att.Title` is empty, but it is never reached for Gemini notes because the Calendar API always populates the title field.
+
+## Goals / Non-Goals
+
+**Goals:**
+- Shortcuts are named after the actual Drive file, not the calendar attachment title
+- Drive API calls for file names are cached per file ID within a single run to avoid redundant requests
+- Existing shortcut behavior is preserved for attachments where the title already matches the file name
+
+**Non-Goals:**
+- Renaming existing shortcuts that were already created with "Notes by Gemini" -- users can re-run the organizer and the shortcut-exists check will skip duplicates
+- Changing how transcripts or other attachment types are named -- only the title resolution order changes, which is transparent
+
+## Decisions
+
+### D1: Always prefer Drive file name over attachment title
+
+**Decision**: Call `GetFileName()` first for every attachment. Use its result as the shortcut name. Fall back to `att.Title` only if the API call fails. Fall back to a truncated file ID if both are unavailable.
+
+**Rationale**: The Drive file name is the authoritative name set by the document creator (Google or human). The calendar attachment title is a label that may be generic or stale. Preferring the Drive name produces more descriptive, distinguishable shortcuts.
+
+**Alternatives considered**:
+- Only call `GetFileName()` when `att.Title` matches a known generic pattern (e.g., "Notes by Gemini"): rejected because this is fragile -- new generic patterns would require code changes. The unconditional approach is simpler and handles all cases.
+- Construct a name from the event title + date: rejected because this invents a name rather than using the actual file name, which may confuse users who expect the shortcut to match the file.
+
+### D2: Cache GetFileName results per file ID
+
+**Decision**: Use the existing `ownershipCache` pattern -- maintain a `map[string]string` for file name lookups within `SyncCalendarAttachments`. If a file ID has been resolved, reuse the cached name.
+
+**Rationale**: The same file ID can appear in multiple calendar events (e.g., a recurring meeting's notes). Caching avoids redundant Drive API calls and keeps the performance impact proportional to unique files, not total attachments.
+
+## Risks / Trade-offs
+
+- **[Additional API calls]** → Each unique attachment file ID triggers one `GetFileName()` call that wasn't made before. For a typical run with 5-20 unique attachments, this adds 5-20 API calls (well within quota). Mitigated by per-file-ID caching.
+- **[File name may differ from expected]** → If a user has manually renamed a Drive file, the shortcut will use the current name, not the original. This is correct behavior (the shortcut should match the file) but may surprise users who expected the old name.
+- **[GetFileName failure]** → If the Drive API call fails (permissions, network), the system falls back to `att.Title`, preserving the current behavior. No degradation beyond the existing behavior.

--- a/openspec/changes/shortcut-drive-filename/proposal.md
+++ b/openspec/changes/shortcut-drive-filename/proposal.md
@@ -1,0 +1,24 @@
+## Why
+
+When gcal-organizer creates shortcuts in meeting folders, it names them using the calendar attachment title (`att.Title`) rather than the actual Drive file name. For Google's auto-generated meeting notes, the attachment title is always "Notes by Gemini", but the actual file in Drive has a descriptive name like "Tanya / Joy 1-1 - 2026/02/12 13:55 EST - Notes by Gemini". This makes all Gemini notes shortcuts indistinguishable when browsing meeting folders. (GitHub issue #15)
+
+## What Changes
+
+- Always fetch the actual Drive file name via `GetFileName()` when creating shortcuts for calendar attachments, instead of using the generic attachment title
+- Fall back to `att.Title` only when the Drive API call fails
+- Cache `GetFileName()` results per file ID to avoid redundant API calls (the same file ID may appear across events)
+
+## Capabilities
+
+### New Capabilities
+
+- `shortcut-file-naming`: Use the actual Google Drive file name for shortcut creation instead of the calendar attachment title
+
+### Modified Capabilities
+
+## Impact
+
+- `internal/organizer/organizer.go`: Change the attachment title resolution logic in `SyncCalendarAttachments()` (lines 439-448) to always call `GetFileName()` first
+- `internal/organizer/organizer_test.go`: Update tests to verify `GetFileName()` is called and its result is used for shortcut names
+- One additional Drive API call per unique attachment file ID (mitigated by caching)
+- No breaking changes -- shortcuts that already have correct names (e.g., transcripts where `att.Title` matches the file name) are unaffected

--- a/openspec/changes/shortcut-drive-filename/specs/shortcut-file-naming/spec.md
+++ b/openspec/changes/shortcut-drive-filename/specs/shortcut-file-naming/spec.md
@@ -1,0 +1,31 @@
+## ADDED Requirements
+
+### Requirement: Shortcuts use Drive file name
+When creating a shortcut for a calendar event attachment, the system SHALL use the actual Google Drive file name (retrieved via `GetFileName()`) as the shortcut name, rather than the calendar attachment title.
+
+#### Scenario: Gemini notes shortcut uses Drive file name
+- **WHEN** a calendar event has an attachment titled "Notes by Gemini" with a Drive file named "Sprint Planning - 2026/04/11 09:00 EST - Notes by Gemini"
+- **THEN** the shortcut is created with the name "Sprint Planning - 2026/04/11 09:00 EST - Notes by Gemini"
+
+#### Scenario: Transcript shortcut retains correct name
+- **WHEN** a calendar event has an attachment titled "Sprint Planning - Transcript" and the Drive file has the same name
+- **THEN** the shortcut is created with the name "Sprint Planning - Transcript" (no change in behavior)
+
+#### Scenario: GetFileName API failure falls back to attachment title
+- **WHEN** a calendar event has an attachment titled "Notes by Gemini" and the `GetFileName()` API call fails
+- **THEN** the shortcut is created with the name "Notes by Gemini" (fallback to attachment title)
+
+#### Scenario: Both title and GetFileName unavailable
+- **WHEN** a calendar event has an attachment with an empty title and the `GetFileName()` API call fails
+- **THEN** the shortcut is created with a truncated file ID as the name (e.g., "attachment (abc12345...)")
+
+### Requirement: File name lookups are cached per run
+The system SHALL cache the results of `GetFileName()` calls per file ID within a single `SyncCalendarAttachments` execution to avoid redundant Drive API requests.
+
+#### Scenario: Same file ID across multiple events
+- **WHEN** two calendar events reference the same attachment file ID
+- **THEN** `GetFileName()` is called only once for that file ID and the cached result is reused for the second event
+
+#### Scenario: Cache does not persist across runs
+- **WHEN** the user runs `gcal-organizer run` twice
+- **THEN** each run starts with a fresh cache (no stale file names from previous runs)

--- a/openspec/changes/shortcut-drive-filename/tasks.md
+++ b/openspec/changes/shortcut-drive-filename/tasks.md
@@ -1,0 +1,19 @@
+## 1. Change Title Resolution Logic
+
+- [x] 1.1 In `internal/organizer/organizer.go` `SyncCalendarAttachments()`, add a `fileNameCache map[string]string` alongside the existing `ownershipCache` at the top of the function
+- [x] 1.2 Replace the attachment title resolution block (lines 439-448) to always call `GetFileName()` first, check the cache before making the API call, and fall back to `att.Title` on error
+- [x] 1.3 Use the cached/resolved file name for `CreateShortcut()`, `logCalendarAction()`, notes tracking, and decision doc tracking — ensuring all downstream consumers see the Drive file name
+
+## 2. Tests
+
+- [x] 2.1 Add test `TestSyncCalendarAttachments_UsesGetFileNameForShortcut` in `internal/organizer/organizer_test.go` verifying that `GetFileName()` is called and its result is passed to `CreateShortcut()` when `att.Title` is a generic name like "Notes by Gemini"
+- [x] 2.2 Add test `TestSyncCalendarAttachments_FallsBackToAttTitle` verifying that when `GetFileName()` returns an error, `att.Title` is used as the shortcut name
+- [x] 2.3 Add test `TestSyncCalendarAttachments_CachesFileNameLookups` verifying that for two events with the same attachment file ID, `GetFileName()` is called only once
+
+## 3. Verification
+
+- [x] 3.1 Run `go build ./cmd/gcal-organizer` to verify compilation
+- [x] 3.2 Run `go test -race -count=1 ./...` to verify all tests pass
+- [x] 3.3 Run `go vet ./...` and `gofmt -l .` to verify code quality
+<!-- spec-review: passed -->
+<!-- code-review: passed -->


### PR DESCRIPTION
## Summary

- Always resolve the actual Google Drive file name via GetFileName() for calendar attachment shortcuts, instead of using the generic calendar attachment title (e.g., "Notes by Gemini")
- Cache file name lookups per file ID across events to minimize API calls
- Fall back to att.Title when the Drive API call fails
- Update decision doc detection to match against both the attachment title and the resolved file name
- Includes 3 new tests: Drive name used, fallback behavior, cache prevents duplicate calls

Closes #15