### PR TITLE
feat(014): add local AI via Ollama for sensitivity gating and local inference

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -21,6 +21,8 @@ Auto-generated from all feature plans. Last updated: 2026-02-17
 - Local filesystem (`~/.gcal-organizer/decisions/` default). No database. (012-decision-markdown-export)
 - Go 1.24.0 (toolchain go1.24.12) + `github.com/spf13/viper` (config), `github.com/spf13/cobra` (CLI), `github.com/charmbracelet/log` (logging), `github.com/zalando/go-keyring` (secrets) — all existing; no new dependencies (013-yaml-config-decision-export)
 - Local filesystem (`~/.gcal-organizer/config.yaml` replaces `~/.gcal-organizer/.env`). Secrets remain in OS keychain. (013-yaml-config-decision-export)
+- Go 1.24.0 (toolchain go1.24.12) + `net/http` (Ollama REST API — no SDK), `github.com/spf13/cobra` (CLI), `github.com/spf13/viper` (config), `github.com/charmbracelet/log` (logging), `github.com/charmbracelet/huh` (interactive prompts) (014-local-ai-ollama)
+- N/A (no new data persistence; configuration via existing YAML config file) (014-local-ai-ollama)
 
 - **Language**: Go 1.24+
 - **CLI Framework**: github.com/spf13/cobra
@@ -83,9 +85,9 @@ make install-hooks
 - New features require documentation before completion
 
 ## Recent Changes
+- 014-local-ai-ollama: Added Go 1.24.0 (toolchain go1.24.12) + `net/http` (Ollama REST API — no SDK), `github.com/spf13/cobra` (CLI), `github.com/spf13/viper` (config), `github.com/charmbracelet/log` (logging), `github.com/charmbracelet/huh` (interactive prompts)
 - 013-yaml-config-decision-export: Added Go 1.24.0 (toolchain go1.24.12) + `github.com/spf13/viper` (config), `github.com/spf13/cobra` (CLI), `github.com/charmbracelet/log` (logging), `github.com/zalando/go-keyring` (secrets) — all existing; no new dependencies
 - 012-decision-markdown-export: Added Go 1.24.0 (toolchain go1.24.12) + `github.com/spf13/cobra` (CLI), `github.com/spf13/viper` (config), `github.com/charmbracelet/log` (logging) — all existing; no new dependencies
-- 011-next-steps-heading: Added Go 1.24+ (toolchain go1.24.12) + `google.golang.org/api/docs/v1` (Docs API), Playwright via `npx tsx` (browser automation)
 
 ### 001-gcal-organizer-cli
 Core CLI implementation with Google Workspace integration and Gemini AI for action item extraction.

--- a/README.md
+++ b/README.md
@@ -61,6 +61,7 @@ Google Drive
 | **Go 1.24+** | Build the CLI | [go.dev/dl](https://go.dev/dl/) |
 | **Node.js 18+** | Browser automation for task assignment | [nodejs.org](https://nodejs.org/) |
 | **Google Chrome** | Task assignment via Playwright | [google.com/chrome](https://www.google.com/chrome/) |
+| **Ollama** | Local AI for sensitivity gate and task assignment | [ollama.com](https://ollama.com/) |
 | **GCP Project** | OAuth2 credentials + Gemini API key | [Setup Guide](docs/SETUP.md) |
 
 ### Install via Homebrew (macOS & Linux)
@@ -197,9 +198,11 @@ GCAL_DECISIONS_EXPORT_DIR="~/.gcal-organizer/decisions"  # Default
 
 ## 🔒 Data Privacy
 
-**What goes to Gemini AI**: Individual checkbox items for task assignment (e.g., `"@jordan review the API spec by Friday"`) and full transcript text for decision extraction. The tool does *not* upload entire documents for task assignment — it extracts checkbox text via the Google Docs API. For decision extraction (Step 4), the full transcript tab content is sent to Gemini for analysis.
+**Sensitivity gate**: When enabled (default), every transcript is screened locally by Granite Guardian before any cloud processing. Sensitive transcripts are skipped entirely.
 
-**What stays local**: OAuth tokens, credentials, and configuration are stored securely and never transmitted.
+**What goes to Gemini AI**: Only decision extraction uses Gemini (unless local-only mode is enabled). Task assignment runs locally via Ollama. In local-only mode, no data is sent to cloud AI services.
+
+**What stays local**: OAuth tokens, credentials, configuration, and all local AI processing are stored securely and never transmitted to cloud AI services.
 
 ### Secure Credential Storage
 
@@ -251,6 +254,63 @@ Step 4 automatically processes meeting transcript documents to extract and categ
 
 **Error handling**: If Gemini fails on a document, it's skipped with a warning. The next run will retry since no tab was created.
 
+## 🤖 Local AI (Ollama)
+
+gcal-organizer integrates with [Ollama](https://ollama.com/) for local AI processing using IBM Granite models:
+
+### Sensitivity Gate
+
+Every meeting transcript is screened locally by **Granite Guardian** before any cloud processing. If sensitive content is detected (HR discussions, legal matters, compensation, health information, termination planning), the transcript is skipped entirely — no cloud AI calls, no document modifications, no local exports.
+
+```bash
+# View sensitivity classifications in logs
+gcal-organizer run --verbose
+
+# Preview classifications without skipping
+gcal-organizer run --dry-run
+```
+
+### Local Task Assignment
+
+Task assignment (identifying who is responsible for each action item) runs locally using **Granite 3.2:8b** instead of Gemini. Action item content never leaves your machine.
+
+### Local-Only Mode
+
+For maximum privacy, enable local-only mode to run all AI processing locally:
+
+```yaml
+# In ~/.gcal-organizer/config.yaml
+ollama:
+  local_only: true
+```
+
+In this mode, decision extraction also uses the local model instead of Gemini. No cloud AI calls are made.
+
+### Configuration
+
+```yaml
+# ~/.gcal-organizer/config.yaml
+ollama:
+  enabled: true                          # Enable local AI features
+  endpoint: "http://localhost:11434"      # Ollama API endpoint
+  timeout: 120                           # Request timeout (seconds)
+  sensitivity:
+    enabled: true                        # Enable sensitivity gate
+    model: "granite-guardian"             # Sensitivity model
+    threshold: 0.7                       # Sensitivity threshold (0.0-1.0)
+  assignments:
+    model: "granite3.2:8b"               # Task assignment model
+  local_only: false                      # All AI processing local
+```
+
+### Troubleshooting
+
+| Issue | Fix |
+|-------|-----|
+| "Ollama is configured but not available" | Run `ollama serve` to start the service |
+| "Model not available" | Run `ollama pull <model>` to download the model |
+| "Ollama binary not found" | Install with `brew install ollama` (macOS) |
+
 ## 📁 Project Structure
 
 ```
@@ -264,6 +324,7 @@ gcal-organizer/
 │   ├── drive/                 # Drive folder/file operations
 │   ├── export/                # Decision markdown export (local files)
 │   ├── gemini/                # Gemini AI assignee + decision extraction
+│   ├── ollama/                # Local AI via Ollama (sensitivity, assignments, decisions)
 │   └── organizer/             # Workflow orchestration
 ├── browser/                   # Playwright task assignment script (TypeScript)
 ├── .specify/                  # Spec-kit artifacts

--- a/cmd/gcal-organizer/assign_tasks.go
+++ b/cmd/gcal-organizer/assign_tasks.go
@@ -19,6 +19,7 @@ import (
 	"github.com/jflowers/gcal-organizer/internal/gemini"
 	"github.com/jflowers/gcal-organizer/internal/secrets"
 	"github.com/jflowers/gcal-organizer/internal/ux"
+	"github.com/jflowers/gcal-organizer/pkg/models"
 	"github.com/spf13/cobra"
 )
 
@@ -96,51 +97,71 @@ Requires: Node.js and the browser/ directory to be set up.`,
 			return ux.MissingAPIKey()
 		}
 
+		// Use Gemini as the extractor for the standalone assign-tasks command.
+		// The run command handles Ollama substitution separately.
+		var extractor AssigneeExtractor = geminiClient
 		if dryRun {
-			return runAssignTasksDryRunWithServices(ctx, cfg, docsSvc, geminiClient, docID)
+			return runAssignTasksDryRunWithServices(ctx, cfg, docsSvc, extractor, docID)
 		}
-		return runAssignTasksBrowserWithServices(ctx, cfg, docsSvc, geminiClient, docID)
+		return runAssignTasksBrowserWithServices(ctx, cfg, docsSvc, extractor, docID)
 	},
 }
 
 // initDocsAndGemini is a shared helper that initialises the Docs service and
 // Gemini client, both of which are required by every assign-tasks flow.
 func initDocsAndGemini(ctx context.Context, cfg *config.Config, store secrets.SecretStore) (*docs.Service, *gemini.Client, error) {
-	oauthClient, err := auth.NewOAuthClient(store, cfg.CredentialsFile)
+	docsSvc, err := initDocsOnly(ctx, cfg, store)
 	if err != nil {
-		return nil, nil, ux.OAuthSetupFailed(cfg.CredentialsFile)
-	}
-	httpClient, err := oauthClient.GetClient(ctx)
-	if err != nil {
-		return nil, nil, ux.AuthFailed()
-	}
-	docsSvc, err := docs.NewService(ctx, httpClient)
-	if err != nil {
-		return nil, nil, fmt.Errorf("failed to initialize Docs service: %w\n\nRun 'gcal-organizer doctor' for diagnostics", err)
+		return nil, nil, err
 	}
 	geminiClient, err := gemini.NewClient(ctx, cfg.GeminiAPIKey, cfg.GeminiModel)
 	if err != nil {
-		return nil, nil, ux.MissingAPIKey()
+		return docsSvc, nil, ux.MissingAPIKey()
 	}
 	return docsSvc, geminiClient, nil
 }
 
+// initDocsOnly creates a Docs service without requiring a Gemini API key.
+// Used in local-only mode where Gemini is not needed but Docs API access
+// is still required for transcript extraction and tab creation.
+func initDocsOnly(ctx context.Context, cfg *config.Config, store secrets.SecretStore) (*docs.Service, error) {
+	oauthClient, err := auth.NewOAuthClient(store, cfg.CredentialsFile)
+	if err != nil {
+		return nil, ux.OAuthSetupFailed(cfg.CredentialsFile)
+	}
+	httpClient, err := oauthClient.GetClient(ctx)
+	if err != nil {
+		return nil, ux.AuthFailed()
+	}
+	docsSvc, err := docs.NewService(ctx, httpClient)
+	if err != nil {
+		return nil, fmt.Errorf("failed to initialize Docs service: %w\n\nRun 'gcal-organizer doctor' for diagnostics", err)
+	}
+	return docsSvc, nil
+}
+
+// AssigneeExtractor is the interface for extracting assignees from checkbox items.
+// Both gemini.Client and ollama.Assigner satisfy this interface.
+type AssigneeExtractor interface {
+	ExtractAssigneesFromCheckboxes(ctx context.Context, items []models.CheckboxItem) ([]models.CheckboxAssignment, error)
+}
+
 // extractUnassignedItems returns the subset of checkbox items that have not
 // yet been assigned (IsProcessed == false).
-func extractUnassignedItems(checkboxes []*docs.CheckboxItem) []gemini.CheckboxItem {
-	var items []gemini.CheckboxItem
+func extractUnassignedItems(checkboxes []*docs.CheckboxItem) []models.CheckboxItem {
+	var items []models.CheckboxItem
 	for i, cb := range checkboxes {
 		if cb.IsProcessed {
 			continue
 		}
-		items = append(items, gemini.CheckboxItem{Index: i, Text: cb.Text})
+		items = append(items, models.CheckboxItem{Index: i, Text: cb.Text})
 	}
 	return items
 }
 
 // runAssignTasksDryRunWithServices analyses a document and prints what would be assigned.
 // Uses pre-initialized services to avoid redundant OAuth/Gemini client creation.
-func runAssignTasksDryRunWithServices(ctx context.Context, cfg *config.Config, docsSvc *docs.Service, geminiClient *gemini.Client, docID string) error {
+func runAssignTasksDryRunWithServices(ctx context.Context, cfg *config.Config, docsSvc *docs.Service, extractor AssigneeExtractor, docID string) error {
 	checkboxes, err := docsSvc.ExtractCheckboxItems(ctx, docID)
 	if err != nil {
 		return fmt.Errorf("failed to extract checkboxes: %w", err)
@@ -158,8 +179,8 @@ func runAssignTasksDryRunWithServices(ctx context.Context, cfg *config.Config, d
 		return nil
 	}
 
-	fmt.Println("🤖 Analyzing tasks with Gemini...")
-	assignments, err := geminiClient.ExtractAssigneesFromCheckboxes(ctx, items)
+	fmt.Println("🤖 Analyzing tasks...")
+	assignments, err := extractor.ExtractAssigneesFromCheckboxes(ctx, items)
 	if err != nil {
 		return fmt.Errorf("failed to extract assignees: %w", err)
 	}
@@ -198,7 +219,7 @@ type scriptOutput struct {
 
 // runAssignTasksBrowserWithServices extracts assignees then invokes the Playwright script.
 // Uses pre-initialized services to avoid redundant OAuth/Gemini client creation.
-func runAssignTasksBrowserWithServices(ctx context.Context, cfg *config.Config, docsSvc *docs.Service, geminiClient *gemini.Client, docID string) error {
+func runAssignTasksBrowserWithServices(ctx context.Context, cfg *config.Config, docsSvc *docs.Service, extractor AssigneeExtractor, docID string) error {
 	checkboxes, err := docsSvc.ExtractCheckboxItems(ctx, docID)
 	if err != nil {
 		return fmt.Errorf("failed to extract checkboxes: %w", err)
@@ -216,8 +237,8 @@ func runAssignTasksBrowserWithServices(ctx context.Context, cfg *config.Config, 
 		return nil
 	}
 
-	fmt.Println("🤖 Analyzing tasks with Gemini...")
-	assignments, err := geminiClient.ExtractAssigneesFromCheckboxes(ctx, items)
+	fmt.Println("🤖 Analyzing tasks...")
+	assignments, err := extractor.ExtractAssigneesFromCheckboxes(ctx, items)
 	if err != nil {
 		return fmt.Errorf("failed to extract assignees: %w", err)
 	}
@@ -232,7 +253,7 @@ func runAssignTasksBrowserWithServices(ctx context.Context, cfg *config.Config, 
 }
 
 // runBrowserScript serialises assignments and invokes the Playwright script.
-func runBrowserScript(ctx context.Context, cfg *config.Config, docID string, assignments []gemini.CheckboxAssignment) error {
+func runBrowserScript(ctx context.Context, cfg *config.Config, docID string, assignments []models.CheckboxAssignment) error {
 	var payload []browserAssignment
 	for _, a := range assignments {
 		email := a.Assignee
@@ -372,9 +393,9 @@ func findBrowserDir() (string, error) {
 
 // runAssignTasksForDoc scans a document for unassigned checkboxes and runs
 // browser automation to assign them. Returns (assigned, failed, error).
-// docsSvc and geminiClient should be pre-initialized by the caller to avoid
-// redundant OAuth/Gemini client creation per document.
-func runAssignTasksForDoc(ctx context.Context, cfg *config.Config, docsSvc *docs.Service, geminiClient *gemini.Client, docID string) (int, int, error) {
+// docsSvc and extractor should be pre-initialized by the caller to avoid
+// redundant client creation per document.
+func runAssignTasksForDoc(ctx context.Context, cfg *config.Config, docsSvc *docs.Service, extractor AssigneeExtractor, docID string) (int, int, error) {
 	checkboxes, err := docsSvc.ExtractCheckboxItems(ctx, docID)
 	if err != nil {
 		return 0, 0, fmt.Errorf("extract checkboxes: %w", err)
@@ -389,9 +410,9 @@ func runAssignTasksForDoc(ctx context.Context, cfg *config.Config, docsSvc *docs
 	}
 
 	fmt.Printf("   📄 Doc %s: %d checkboxes, %d unassigned\n", docID[:min(8, len(docID))], len(checkboxes), len(items))
-	fmt.Println("   🤖 Analyzing tasks with Gemini...")
+	fmt.Println("   🤖 Analyzing tasks...")
 
-	assignments, err := geminiClient.ExtractAssigneesFromCheckboxes(ctx, items)
+	assignments, err := extractor.ExtractAssigneesFromCheckboxes(ctx, items)
 	if err != nil {
 		return 0, 0, fmt.Errorf("extract assignees: %w", err)
 	}

--- a/cmd/gcal-organizer/main.go
+++ b/cmd/gcal-organizer/main.go
@@ -16,6 +16,9 @@ import (
 	"path/filepath"
 	"syscall"
 
+	"net/url"
+	"strings"
+
 	"github.com/charmbracelet/huh"
 	"github.com/jflowers/gcal-organizer/internal/auth"
 	"github.com/jflowers/gcal-organizer/internal/calendar"
@@ -23,6 +26,7 @@ import (
 	"github.com/jflowers/gcal-organizer/internal/drive"
 	"github.com/jflowers/gcal-organizer/internal/export"
 	"github.com/jflowers/gcal-organizer/internal/logging"
+	"github.com/jflowers/gcal-organizer/internal/ollama"
 	"github.com/jflowers/gcal-organizer/internal/organizer"
 	"github.com/jflowers/gcal-organizer/internal/secrets"
 	"github.com/jflowers/gcal-organizer/internal/ux"
@@ -188,6 +192,44 @@ var runCmd = &cobra.Command{
 			return err
 		}
 
+		// Initialize Ollama client and sensitivity gate when enabled.
+		var ollamaClient *ollama.Client
+		if cfg.Ollama.Enabled {
+			ollamaClient = ollama.NewClient(cfg.Ollama.Endpoint, cfg.Ollama.Timeout)
+
+			// S-1: Warn when Ollama endpoint is not localhost.
+			if !isLocalEndpoint(cfg.Ollama.Endpoint) {
+				logging.Logger.Warn("Ollama endpoint is not localhost — sensitive transcripts will be sent over the network",
+					"endpoint", cfg.Ollama.Endpoint)
+			}
+
+			// FR-008: Hard-stop when Ollama configured but unavailable.
+			if !ollamaClient.HealthCheck() {
+				return fmt.Errorf("Ollama is configured but not available at %s\n\n"+
+					"Fix steps:\n"+
+					"  1. Install: brew install ollama\n"+
+					"  2. Start:   ollama serve\n"+
+					"  3. Verify:  ollama list\n\n"+
+					"Or disable: set ollama.enabled=false in config.yaml", cfg.Ollama.Endpoint)
+			}
+
+			// FR-010: Validate sensitivity model availability.
+			if cfg.Ollama.Sensitivity.Enabled {
+				if !ollamaClient.ModelAvailable(cfg.Ollama.Sensitivity.Model) {
+					return fmt.Errorf("Ollama sensitivity model %q is not available\n\n"+
+						"Fix: ollama pull %s", cfg.Ollama.Sensitivity.Model, cfg.Ollama.Sensitivity.Model)
+				}
+				guardian := ollama.NewGuardian(ollamaClient, cfg.Ollama.Sensitivity.Model)
+				org.SetSensitivityClassifier(guardian)
+			}
+
+			// Validate assignment model availability.
+			if !ollamaClient.ModelAvailable(cfg.Ollama.Assignments.Model) {
+				return fmt.Errorf("Ollama assignment model %q is not available\n\n"+
+					"Fix: ollama pull %s", cfg.Ollama.Assignments.Model, cfg.Ollama.Assignments.Model)
+			}
+		}
+
 		// Steps 1 & 2: Organize documents + Sync calendar
 		if err := org.RunFullWorkflow(ctx); err != nil {
 			return err
@@ -203,17 +245,26 @@ var runCmd = &cobra.Command{
 			fmt.Println("───────────────────────────────────────────────────────────")
 			fmt.Printf("   Found %d Notes documents to scan for tasks\n", len(docIDs))
 
-			// Initialize Docs+Gemini once for all documents to avoid
-			// redundant OAuth/Gemini client creation per document.
+			// Initialize Docs service and assignee extractor.
+			// When Ollama is enabled, use local assigner (FR-013).
+			// Otherwise, use Gemini.
 			taskDocsSvc, taskGeminiClient, taskInitErr := initDocsAndGemini(ctx, cfg, store)
 			if taskInitErr != nil {
 				fmt.Printf("   ⚠️  Error initializing services for Step 3: %v\n", taskInitErr)
 			} else {
+				var extractor AssigneeExtractor
+				if cfg.Ollama.Enabled && ollamaClient != nil {
+					extractor = ollama.NewAssigner(ollamaClient, cfg.Ollama.Assignments.Model)
+					logging.Logger.Info("Using local AI for task assignment", "model", cfg.Ollama.Assignments.Model)
+				} else {
+					extractor = taskGeminiClient
+				}
+
 				totalAssigned := 0
 				totalFailed := 0
 
 				for _, docID := range docIDs {
-					assigned, failed, err := runAssignTasksForDoc(ctx, cfg, taskDocsSvc, taskGeminiClient, docID)
+					assigned, failed, err := runAssignTasksForDoc(ctx, cfg, taskDocsSvc, extractor, docID)
 					if err != nil {
 						fmt.Printf("   ⚠️  Error processing doc %s: %v\n", docID[:min(8, len(docID))], err)
 						continue
@@ -244,14 +295,47 @@ var runCmd = &cobra.Command{
 				fmt.Printf("   Found %d transcript documents to process\n", len(decisionDocContexts))
 			}
 
+			// FR-016: local-only mode requires Ollama enabled.
+			if cfg.Ollama.LocalOnly && !cfg.Ollama.Enabled {
+				return fmt.Errorf("local-only mode requires Ollama to be enabled\n\n" +
+					"Fix: set ollama.enabled=true in config.yaml, or disable local_only")
+			}
+
 			// Create decision exporter with configured output directory
 			decisionExporter := export.NewExporter(cfg.Decisions.ExportDir, logging.Logger)
 
-			// Initialize services once for all documents
+			// Initialize services once for all documents.
+			// When local-only mode is active, use local decision extractor
+			// instead of Gemini (FR-016, FR-017).
+			var geminiSvc organizer.GeminiService
 			docsSvc, geminiClient, initErr := initDocsAndGemini(ctx, cfg, store)
 			if initErr != nil {
-				fmt.Printf("   ⚠️  Error initializing services for Step 4: %v\n", initErr)
-			} else {
+				// In local-only mode, Gemini init failure is not fatal for decisions.
+				// We still need docsSvc for transcript extraction and tab creation.
+				if cfg.Ollama.Enabled && cfg.Ollama.LocalOnly && ollamaClient != nil {
+					if docsSvc == nil {
+						// initDocsAndGemini may have returned docsSvc even on Gemini failure,
+						// but if OAuth/Docs also failed, try docs-only initialization.
+						var docsErr error
+						docsSvc, docsErr = initDocsOnly(ctx, cfg, store)
+						if docsErr != nil {
+							fmt.Printf("   ⚠️  Error initializing Docs service for Step 4: %v\n", docsErr)
+						}
+					}
+					logging.Logger.Debug("Gemini init skipped, using local-only mode for decisions", "error", initErr)
+				} else {
+					fmt.Printf("   ⚠️  Error initializing services for Step 4: %v\n", initErr)
+				}
+			}
+
+			if cfg.Ollama.Enabled && cfg.Ollama.LocalOnly && ollamaClient != nil {
+				geminiSvc = ollama.NewDecisionExtractor(ollamaClient, cfg.Ollama.Assignments.Model)
+				logging.Logger.Info("Using local AI for decision extraction", "model", cfg.Ollama.Assignments.Model)
+			} else if geminiClient != nil {
+				geminiSvc = geminiClient
+			}
+
+			if docsSvc != nil && geminiSvc != nil {
 				totalFailed := 0
 
 				for _, docCtx := range decisionDocContexts {
@@ -260,10 +344,52 @@ var runCmd = &cobra.Command{
 						logging.Logger.Debug("Skipping meeting not in allowlist", "title", docCtx.EventTitle)
 						continue
 					}
+
+					// Sensitivity gate: classify transcript before processing (FR-001).
+					// Inserted here (same level as allowlist filter) to keep
+					// ExtractDecisionsForDoc focused on extraction, not gating.
+					if cfg.Ollama.Enabled && cfg.Ollama.Sensitivity.Enabled {
+						sensitivityResult, classifyErr := org.ClassifyTranscript(ctx, docCtx, docsSvc)
+						if classifyErr != nil {
+							// Hard-stop on classification failure (FR-009).
+							return fmt.Errorf("sensitivity classification failed for doc %s: %w",
+								docCtx.DocID[:min(8, len(docCtx.DocID))], classifyErr)
+						}
+						if sensitivityResult != nil {
+							docURL := fmt.Sprintf("https://docs.google.com/document/d/%s/edit", docCtx.DocID)
+							if sensitivityResult.Score >= cfg.Ollama.Sensitivity.Threshold {
+								// FR-004: Log category+score+doc URL at INFO.
+								logging.Logger.Info("Skipped sensitive transcript",
+									"category", sensitivityResult.Category,
+									"score", sensitivityResult.Score,
+									"doc", docURL,
+								)
+								// FR-004: Reasoning at DEBUG only.
+								logging.Logger.Debug("Sensitivity reasoning",
+									"reasoning", sensitivityResult.Reasoning,
+								)
+								org.AddSensitivitySkipped()
+								if !dryRun {
+									// FR-007: In dry-run, log but proceed.
+									continue
+								}
+								// FR-007: Dry-run proceeds with processing.
+								logging.Logger.Info("Dry-run: would skip sensitive transcript, but proceeding")
+							} else {
+								org.AddSensitivityProcessed()
+								logging.Logger.Debug("Transcript passed sensitivity gate",
+									"category", sensitivityResult.Category,
+									"score", sensitivityResult.Score,
+									"doc", docURL,
+								)
+							}
+						}
+					}
+
 					if !dryRun {
 						fmt.Printf("   📄 Processing doc %s (source: %s)\n", docCtx.DocID[:min(8, len(docCtx.DocID))], docCtx.Source)
 					}
-					err := org.ExtractDecisionsForDoc(ctx, docCtx, docsSvc, geminiClient, decisionExporter, dryRun)
+					err := org.ExtractDecisionsForDoc(ctx, docCtx, docsSvc, geminiSvc, decisionExporter, dryRun)
 					if err != nil {
 						fmt.Printf("   ⚠️  Error processing doc %s: %v\n", docCtx.DocID[:min(8, len(docCtx.DocID))], err)
 						totalFailed++
@@ -273,7 +399,7 @@ var runCmd = &cobra.Command{
 				// Only add externally-tracked failures; processed/skipped counts are
 				// managed internally by ExtractDecisionsForDoc via organizer stats.
 				org.AddDecisionStats(0, 0, totalFailed)
-			}
+			} // end if docsSvc != nil && geminiSvc != nil
 			fmt.Println()
 		}
 
@@ -473,6 +599,18 @@ func initConfig() {
 
 // loadDotEnv, validEnvKey, maskSecret, and truncateText have been extracted
 // to internal/config/dotenv.go and internal/ux/format.go respectively.
+
+// isLocalEndpoint returns true if the given URL points to localhost.
+// Used for S-1: warn when Ollama endpoint is not localhost.
+func isLocalEndpoint(endpoint string) bool {
+	u, err := url.Parse(endpoint)
+	if err != nil {
+		return false
+	}
+	host := u.Hostname()
+	return host == "localhost" || host == "127.0.0.1" || host == "::1" ||
+		strings.HasPrefix(host, "127.")
+}
 
 func main() {
 	if err := rootCmd.Execute(); err != nil {

--- a/cmd/gcal-organizer/selfservice.go
+++ b/cmd/gcal-organizer/selfservice.go
@@ -16,6 +16,8 @@ import (
 
 	"github.com/charmbracelet/huh"
 	"github.com/charmbracelet/lipgloss"
+	"github.com/jflowers/gcal-organizer/internal/config"
+	"github.com/jflowers/gcal-organizer/internal/ollama"
 	"github.com/jflowers/gcal-organizer/internal/secrets"
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
@@ -346,6 +348,63 @@ var doctorCmd = &cobra.Command{
 			warned++
 		}
 
+		// 11-14. Ollama checks (FR-027: skip when disabled)
+		cfg, _, _, cfgErr := loadConfigAndStore()
+		if cfgErr != nil {
+			// If config load fails, try defaults
+			cfg = config.DefaultConfig()
+		}
+
+		if cfg.Ollama.Enabled {
+			// Check 11: Ollama binary installed
+			if _, lookErr := exec.LookPath("ollama"); lookErr == nil {
+				fmt.Println(styledPass("Ollama binary installed"))
+				passed++
+			} else {
+				fmt.Println(styledFail("Ollama binary not found"))
+				fmt.Println(styledFix("Install: brew install ollama"))
+				failed++
+			}
+
+			// Check 12: Ollama service running
+			ollamaClient := ollama.NewClient(cfg.Ollama.Endpoint, 5)
+			ollamaRunning := ollamaClient.HealthCheck()
+			if ollamaRunning {
+				fmt.Println(styledPass("Ollama service running"))
+				passed++
+			} else {
+				fmt.Println(styledFail("Ollama service not running"))
+				fmt.Println(styledFix("Run: ollama serve"))
+				failed++
+			}
+
+			// Checks 13-14: Model availability (only if service is running)
+			if ollamaRunning {
+				// Check 13: Sensitivity model
+				if ollamaClient.ModelAvailable(cfg.Ollama.Sensitivity.Model) {
+					fmt.Println(styledPass(fmt.Sprintf("Sensitivity model (%s) available", cfg.Ollama.Sensitivity.Model)))
+					passed++
+				} else {
+					fmt.Println(styledFail(fmt.Sprintf("Sensitivity model (%s) not found", cfg.Ollama.Sensitivity.Model)))
+					fmt.Println(styledFix(fmt.Sprintf("Run: ollama pull %s", cfg.Ollama.Sensitivity.Model)))
+					failed++
+				}
+
+				// Check 14: Assignment model
+				if ollamaClient.ModelAvailable(cfg.Ollama.Assignments.Model) {
+					fmt.Println(styledPass(fmt.Sprintf("Assignment model (%s) available", cfg.Ollama.Assignments.Model)))
+					passed++
+				} else {
+					fmt.Println(styledFail(fmt.Sprintf("Assignment model (%s) not found", cfg.Ollama.Assignments.Model)))
+					fmt.Println(styledFix(fmt.Sprintf("Run: ollama pull %s", cfg.Ollama.Assignments.Model)))
+					failed++
+				}
+			} else {
+				fmt.Println(styledWarn("Model checks skipped — Ollama not running"))
+				warned++
+			}
+		}
+
 		// Summary
 		fmt.Println()
 		summaryLine := fmt.Sprintf("  ✅ %d passed  ⚠️  %d warnings  ❌ %d failed", passed, warned, failed)
@@ -446,6 +505,56 @@ var initCmd = &cobra.Command{
 			fmt.Println(styledFix("Download OAuth credentials from Google Cloud Console:"))
 			fmt.Println(subtleStyle.Render("     https://console.cloud.google.com/apis/credentials"))
 			fmt.Println(subtleStyle.Render("     Save as: ~/.gcal-organizer/credentials.json"))
+		}
+
+		// 4. Ollama model pull prompt (FR-028)
+		cfg := config.DefaultConfig()
+		// Try to load actual config if available.
+		if loadedCfg, loadErr := config.Load(); loadErr == nil {
+			cfg = loadedCfg
+		}
+		if cfg.Ollama.Enabled {
+			ollamaClient := ollama.NewClient(cfg.Ollama.Endpoint, 5)
+			if ollamaClient.HealthCheck() {
+				var missingModels []string
+				if !ollamaClient.ModelAvailable(cfg.Ollama.Sensitivity.Model) {
+					missingModels = append(missingModels, cfg.Ollama.Sensitivity.Model)
+				}
+				if !ollamaClient.ModelAvailable(cfg.Ollama.Assignments.Model) {
+					missingModels = append(missingModels, cfg.Ollama.Assignments.Model)
+				}
+
+				if len(missingModels) > 0 && !nonInteractive {
+					var pullConfirm bool
+					form := huh.NewForm(
+						huh.NewGroup(
+							huh.NewConfirm().
+								Title("Local AI models are needed for transcript screening. Pull them now?").
+								Affirmative("Yes").
+								Negative("No").
+								Value(&pullConfirm),
+						),
+					)
+					if err := form.Run(); err == nil && pullConfirm {
+						for _, model := range missingModels {
+							fmt.Printf("   Pulling %s...\n", model)
+							pullCmd := exec.Command("ollama", "pull", model)
+							pullCmd.Stdout = os.Stdout
+							pullCmd.Stderr = os.Stderr
+							if err := pullCmd.Run(); err != nil {
+								fmt.Println(styledWarn(fmt.Sprintf("Failed to pull %s: %v", model, err)))
+							} else {
+								fmt.Println(styledPass(fmt.Sprintf("Pulled %s", model)))
+							}
+						}
+					}
+				} else if len(missingModels) > 0 && nonInteractive {
+					fmt.Println(styledWarn(fmt.Sprintf("Missing Ollama models: %v", missingModels)))
+					fmt.Println(styledFix("Run: ollama pull <model> for each missing model"))
+				} else {
+					fmt.Println(styledPass("All Ollama models available"))
+				}
+			}
 		}
 
 		fmt.Println()
@@ -716,7 +825,42 @@ func generateConfigYAML() string {
 	b.WriteString("  # meetings:\n")
 	b.WriteString("  #   - \"Sprint Planning\"\n")
 	b.WriteString("  #   - \"Design Review\"\n")
-	b.WriteString("  #   - \"Weekly Sync\"\n")
+	b.WriteString("  #   - \"Weekly Sync\"\n\n")
+
+	b.WriteString("# Local AI configuration (Ollama with IBM Granite models)\n")
+	b.WriteString("ollama:\n")
+	b.WriteString("  # Enable local AI features (sensitivity gate, local task assignment)\n")
+	b.WriteString("  # When disabled, all Ollama checks and features are skipped.\n")
+	b.WriteString("  # Default: true\n")
+	b.WriteString("  enabled: true\n\n")
+	b.WriteString("  # Ollama API endpoint\n")
+	b.WriteString("  # Default: http://localhost:11434\n")
+	b.WriteString("  endpoint: \"http://localhost:11434\"\n\n")
+	b.WriteString("  # Request timeout for generation requests (seconds)\n")
+	b.WriteString("  # Default: 120\n")
+	b.WriteString("  timeout: 120\n\n")
+	b.WriteString("  # Sensitivity classification settings\n")
+	b.WriteString("  sensitivity:\n")
+	b.WriteString("    # Enable sensitivity gate\n")
+	b.WriteString("    # Default: true\n")
+	b.WriteString("    enabled: true\n\n")
+	b.WriteString("    # Model for sensitivity classification\n")
+	b.WriteString("    # Default: granite-guardian\n")
+	b.WriteString("    model: \"granite-guardian\"\n\n")
+	b.WriteString("    # Sensitivity threshold (0.0-1.0)\n")
+	b.WriteString("    # Transcripts scoring >= this value are skipped.\n")
+	b.WriteString("    # Default: 0.7\n")
+	b.WriteString("    threshold: 0.7\n\n")
+	b.WriteString("  # Task assignment settings\n")
+	b.WriteString("  assignments:\n")
+	b.WriteString("    # Model for assignee extraction\n")
+	b.WriteString("    # Default: granite3.2:8b\n")
+	b.WriteString("    model: \"granite3.2:8b\"\n\n")
+	b.WriteString("  # Local-only mode\n")
+	b.WriteString("  # When true, all AI processing runs locally (no cloud AI calls).\n")
+	b.WriteString("  # Decision extraction uses the local model instead of Gemini.\n")
+	b.WriteString("  # Default: false\n")
+	b.WriteString("  local_only: false\n")
 
 	return b.String()
 }

--- a/docs/SETUP.md
+++ b/docs/SETUP.md
@@ -13,12 +13,45 @@ This guide walks you through setting up `gcal-organizer` with Google Cloud crede
 - **Go 1.24** or later
 - **Node.js 18+** and npm (for browser-based task assignment)
 - **Google Chrome** (for task assignment via Playwright)
+- **Ollama** (for local AI features — sensitivity gate, local task assignment)
 - A Google account with access to:
   - Google Drive
   - Google Calendar
   - Google Docs
   - Google Tasks
 - A Google Cloud project with billing enabled (for Gemini API)
+
+### Ollama (Local AI)
+
+gcal-organizer uses [Ollama](https://ollama.com/) with IBM Granite models for local AI features:
+- **Sensitivity gate**: Screens transcripts for sensitive content before cloud processing
+- **Local task assignment**: Extracts assignees from action items locally
+- **Local-only mode**: Runs all AI processing locally (no cloud AI calls)
+
+**Install Ollama:**
+
+```bash
+# macOS
+brew install ollama
+
+# Linux
+curl -fsSL https://ollama.com/install.sh | sh
+```
+
+**Pull required models:**
+
+```bash
+ollama pull granite-guardian    # Sensitivity classification
+ollama pull granite3.2:8b       # Task assignment and decision extraction
+```
+
+**Start the Ollama service:**
+
+```bash
+ollama serve
+```
+
+> **Note**: If you don't want to use local AI features, set `ollama.enabled: false` in your `config.yaml`. All Ollama checks and features will be skipped.
 
 ---
 
@@ -251,8 +284,10 @@ rm ~/.gcal-organizer/token.json
 
 ## Data Privacy
 
-- **What goes to Gemini AI**: Only the text of individual checkbox items (e.g., `"@jordan review the API spec by Friday"`). Full document contents are **never** uploaded.
-- **What stays local**: OAuth tokens, API keys, and client credentials are stored in the OS credential store (macOS Keychain / Linux Secret Service) by default. Non-secret configuration remains in `~/.gcal-organizer/.env`. Nothing is transmitted externally.
+- **Sensitivity gate**: When enabled (default), every transcript is screened locally by Granite Guardian before any cloud processing. Sensitive transcripts (HR, legal, financial, health, termination) are skipped entirely — no cloud AI calls, no document modifications.
+- **What goes to Gemini AI**: Only decision extraction uses Gemini (unless local-only mode is enabled). Task assignment runs locally via Ollama.
+- **Local-only mode**: Set `ollama.local_only: true` to prevent all cloud AI calls. All processing runs through local Granite models.
+- **What stays local**: OAuth tokens, API keys, and client credentials are stored in the OS credential store (macOS Keychain / Linux Secret Service) by default. Configuration remains in `~/.gcal-organizer/config.yaml`.
 - **Scopes are minimal**: The app requests only the scopes it needs (see table above).
 - **Offline access**: The token includes refresh capability for long-running use.
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -21,6 +21,50 @@ func mustBindEnv(args ...string) {
 	}
 }
 
+// OllamaConfig holds configuration for the local AI integration via Ollama.
+type OllamaConfig struct {
+	// Enabled controls whether local AI features are active.
+	// When false, all Ollama checks and features are skipped.
+	Enabled bool `mapstructure:"enabled"`
+
+	// Endpoint is the Ollama API base URL (e.g., "http://localhost:11434").
+	Endpoint string `mapstructure:"endpoint"`
+
+	// Timeout is the HTTP request timeout for generation requests, in seconds.
+	Timeout int `mapstructure:"timeout"`
+
+	// Sensitivity holds settings for the sensitivity classification gate.
+	Sensitivity SensitivityConfig `mapstructure:"sensitivity"`
+
+	// Assignments holds settings for local task assignment.
+	Assignments AssignmentsConfig `mapstructure:"assignments"`
+
+	// LocalOnly prevents all cloud AI API calls when true.
+	// Decision extraction uses the local model instead of Gemini.
+	LocalOnly bool `mapstructure:"local_only"`
+}
+
+// SensitivityConfig holds settings for the sensitivity classification gate.
+type SensitivityConfig struct {
+	// Enabled controls whether the sensitivity gate is active (FR-006).
+	// Independent of the top-level OllamaConfig.Enabled toggle.
+	// When false, transcripts are not screened for sensitivity.
+	Enabled bool `mapstructure:"enabled"`
+
+	// Model is the Ollama model name for sensitivity classification.
+	Model string `mapstructure:"model"`
+
+	// Threshold is the minimum score for a transcript to be classified
+	// as sensitive. Comparison is >= (inclusive). Range: 0.0–1.0.
+	Threshold float64 `mapstructure:"threshold"`
+}
+
+// AssignmentsConfig holds settings for local task assignment.
+type AssignmentsConfig struct {
+	// Model is the Ollama model name for assignee extraction.
+	Model string `mapstructure:"model"`
+}
+
 // DecisionsConfig holds configuration for the decision export feature.
 type DecisionsConfig struct {
 	// ExportDir is the output directory for decision markdown files.
@@ -76,6 +120,9 @@ type Config struct {
 
 	// Decisions holds configuration for the decision export feature.
 	Decisions DecisionsConfig `mapstructure:"decisions"`
+
+	// Ollama holds configuration for the local AI integration.
+	Ollama OllamaConfig `mapstructure:"ollama"`
 }
 
 // DefaultConfig returns a Config with default values.
@@ -95,6 +142,20 @@ func DefaultConfig() *Config {
 		ChromeProfilePath: filepath.Join(configDir, "chrome-data"),
 		Decisions: DecisionsConfig{
 			ExportDir: filepath.Join(configDir, "decisions"),
+		},
+		Ollama: OllamaConfig{
+			Enabled:  true,
+			Endpoint: "http://localhost:11434",
+			Timeout:  120,
+			Sensitivity: SensitivityConfig{
+				Enabled:   true,
+				Model:     "granite-guardian",
+				Threshold: 0.7,
+			},
+			Assignments: AssignmentsConfig{
+				Model: "granite3.2:8b",
+			},
+			LocalOnly: false,
 		},
 	}
 }
@@ -120,6 +181,14 @@ func Load() (*Config, error) {
 	mustBindEnv("no-keyring", "GCAL_NO_KEYRING")
 	mustBindEnv("decisions.export_dir", "GCAL_DECISIONS_EXPORT_DIR")
 	mustBindEnv("decisions.meetings", "GCAL_DECISIONS_MEETINGS")
+	mustBindEnv("ollama.enabled", "GCAL_OLLAMA_ENABLED")
+	mustBindEnv("ollama.endpoint", "GCAL_OLLAMA_ENDPOINT")
+	mustBindEnv("ollama.timeout", "GCAL_OLLAMA_TIMEOUT")
+	mustBindEnv("ollama.sensitivity.enabled", "GCAL_OLLAMA_SENSITIVITY_ENABLED")
+	mustBindEnv("ollama.sensitivity.model", "GCAL_OLLAMA_SENSITIVITY_MODEL")
+	mustBindEnv("ollama.sensitivity.threshold", "GCAL_OLLAMA_SENSITIVITY_THRESHOLD")
+	mustBindEnv("ollama.assignments.model", "GCAL_OLLAMA_ASSIGNMENTS_MODEL")
+	mustBindEnv("ollama.local_only", "GCAL_OLLAMA_LOCAL_ONLY")
 
 	// Override defaults with viper values
 	if v := viper.GetString("master_folder_name"); v != "" {
@@ -160,6 +229,34 @@ func Load() (*Config, error) {
 		cfg.Decisions.Meetings = meetings
 	}
 
+	// Ollama configuration overrides from viper (YAML or env vars).
+	// viper.IsSet checks whether a key was explicitly provided (YAML or env),
+	// avoiding overwriting defaults with zero values.
+	if viper.IsSet("ollama.enabled") {
+		cfg.Ollama.Enabled = viper.GetBool("ollama.enabled")
+	}
+	if v := viper.GetString("ollama.endpoint"); v != "" {
+		cfg.Ollama.Endpoint = v
+	}
+	if viper.IsSet("ollama.timeout") {
+		cfg.Ollama.Timeout = viper.GetInt("ollama.timeout")
+	}
+	if viper.IsSet("ollama.sensitivity.enabled") {
+		cfg.Ollama.Sensitivity.Enabled = viper.GetBool("ollama.sensitivity.enabled")
+	}
+	if v := viper.GetString("ollama.sensitivity.model"); v != "" {
+		cfg.Ollama.Sensitivity.Model = v
+	}
+	if viper.IsSet("ollama.sensitivity.threshold") {
+		cfg.Ollama.Sensitivity.Threshold = viper.GetFloat64("ollama.sensitivity.threshold")
+	}
+	if v := viper.GetString("ollama.assignments.model"); v != "" {
+		cfg.Ollama.Assignments.Model = v
+	}
+	if viper.IsSet("ollama.local_only") {
+		cfg.Ollama.LocalOnly = viper.GetBool("ollama.local_only")
+	}
+
 	cfg.Verbose = viper.GetBool("verbose")
 	cfg.DryRun = viper.GetBool("dry-run")
 	cfg.OwnedOnly = viper.GetBool("owned-only")
@@ -189,7 +286,13 @@ func (c *Config) LoadSecrets(store secrets.SecretStore) {
 }
 
 // Validate checks that required configuration values are set.
+// FR-016: When Ollama.LocalOnly is true, GeminiAPIKey is NOT required
+// because all AI processing runs locally.
 func (c *Config) Validate() error {
+	if c.Ollama.Enabled && c.Ollama.LocalOnly {
+		// Local-only mode: Gemini key is optional (FR-016).
+		return nil
+	}
 	if c.GeminiAPIKey == "" {
 		return ux.MissingAPIKey()
 	}

--- a/internal/gemini/client.go
+++ b/internal/gemini/client.go
@@ -38,19 +38,13 @@ func NewClient(ctx context.Context, apiKey, modelName string) (*Client, error) {
 	}, nil
 }
 
-// CheckboxItem represents a checkbox item from a document with its index.
-type CheckboxItem struct {
-	Index int    `json:"index"`
-	Text  string `json:"text"`
-}
+// CheckboxItem is an alias for models.CheckboxItem for backward compatibility.
+// The canonical type is defined in pkg/models/models.go (review finding A-1).
+type CheckboxItem = models.CheckboxItem
 
-// CheckboxAssignment represents an extracted assignment for a checkbox.
-type CheckboxAssignment struct {
-	Index    int    `json:"index"`
-	Text     string `json:"text"`
-	Assignee string `json:"assignee"`
-	Email    string `json:"email"` // Populated after name-to-email resolution
-}
+// CheckboxAssignment is an alias for models.CheckboxAssignment for backward compatibility.
+// The canonical type is defined in pkg/models/models.go (review finding A-1).
+type CheckboxAssignment = models.CheckboxAssignment
 
 // ExtractAssigneesFromCheckboxes extracts assignee names from multiple checkbox items.
 func (c *Client) ExtractAssigneesFromCheckboxes(ctx context.Context, items []CheckboxItem) ([]CheckboxAssignment, error) {

--- a/internal/ollama/assigner.go
+++ b/internal/ollama/assigner.go
@@ -1,0 +1,175 @@
+package ollama
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"regexp"
+	"strings"
+
+	"github.com/jflowers/gcal-organizer/pkg/models"
+)
+
+// TaskAssigner extracts assignees from checkbox action items using
+// a local AI model. Produces results in the same format as the
+// existing cloud-based extraction (FR-014).
+//
+// Note: CheckboxItem and CheckboxAssignment types are defined in
+// pkg/models/models.go so that both internal/ollama and internal/gemini
+// can use them without cross-package dependency (review finding A-1).
+type TaskAssigner interface {
+	// ExtractAssignees identifies the responsible individual for each
+	// checkbox item. Returns assignments only for items with a clear
+	// single assignee; items with group/ambiguous assignees are omitted.
+	ExtractAssignees(ctx context.Context, items []models.CheckboxItem) ([]models.CheckboxAssignment, error)
+}
+
+// Assigner implements TaskAssigner using a local Ollama model.
+type Assigner struct {
+	client *Client
+	model  string
+}
+
+// NewAssigner creates a TaskAssigner that uses the specified model via
+// the given Ollama client.
+func NewAssigner(client *Client, model string) *Assigner {
+	return &Assigner{
+		client: client,
+		model:  model,
+	}
+}
+
+// ExtractAssigneesFromCheckboxes is an alias for ExtractAssignees that matches
+// the same method signature as gemini.Client, allowing both to satisfy the
+// same interface in the caller.
+func (a *Assigner) ExtractAssigneesFromCheckboxes(ctx context.Context, items []models.CheckboxItem) ([]models.CheckboxAssignment, error) {
+	return a.ExtractAssignees(ctx, items)
+}
+
+// ExtractAssignees identifies the responsible individual for each checkbox
+// item using the local AI model. Reuses the same prompt as the Gemini
+// implementation (model-agnostic). Retries once on malformed response,
+// hard-stops on network errors.
+func (a *Assigner) ExtractAssignees(ctx context.Context, items []models.CheckboxItem) ([]models.CheckboxAssignment, error) {
+	if len(items) == 0 {
+		return nil, nil
+	}
+
+	// Build the same prompt as internal/gemini/client.go:ExtractAssigneesFromCheckboxes
+	var itemsList strings.Builder
+	for _, item := range items {
+		itemsList.WriteString(fmt.Sprintf("%d. %s\n", item.Index, item.Text))
+	}
+
+	prompt := fmt.Sprintf(`You are an action item extraction assistant. For each numbered task below, determine if there is a SINGLE, SPECIFIC individual who is clearly responsible.
+
+Tasks:
+%s
+
+Return your response as a JSON array. Each element should have:
+- "index": The task number (integer)
+- "assignee": The full name of *one specific person* responsible (string), or null
+
+CRITICAL Rules for determining the assignee:
+1. ONLY return an assignee when a SINGLE, NAMED INDIVIDUAL is clearly the person who must do the task
+2. The pattern must be "[Person's Name] will...", "[Person's Name] to...", or similar where the person is the SUBJECT performing the action
+3. Return null in ALL of these cases:
+   - A group or team is the subject: "The group will...", "The team will...", "We will..."
+   - Multiple people share responsibility: "Alice and Bob will..."
+   - A person is mentioned but is NOT the one doing the task: "approach Martin" (someone else approaches Martin)
+   - The assignee is vague or unclear: "someone should...", "it was decided..."
+   - No person is mentioned at all
+4. Only return the JSON array, no other text
+
+Example input tasks:
+0. Jay will schedule the follow-up meeting
+1. The group will discuss Martin's proposal
+2. Alice and Bob will prepare the presentation
+3. Sarah will send the summary email
+4. Reach out to the vendor about pricing
+
+Example response:
+[
+  {"index": 0, "assignee": "Jay"},
+  {"index": 1, "assignee": null},
+  {"index": 2, "assignee": null},
+  {"index": 3, "assignee": "Sarah"},
+  {"index": 4, "assignee": null}
+]
+
+Your response:`, itemsList.String())
+
+	var lastErr error
+	for attempt := 0; attempt < 2; attempt++ {
+		response, err := a.client.Generate(ctx, a.model, prompt)
+		if err != nil {
+			// Network/timeout errors: hard-stop immediately (FR-009).
+			return nil, fmt.Errorf("local task assignment failed: %w", err)
+		}
+
+		assignments, parseErr := parseLocalAssignmentsResponse(response, items)
+		if parseErr != nil {
+			lastErr = parseErr
+			continue // Retry on malformed response
+		}
+		return assignments, nil
+	}
+
+	return nil, fmt.Errorf("%w: %v", ErrMalformedResponse, lastErr)
+}
+
+// parseLocalAssignmentsResponse parses the JSON array response from the local model.
+// Same parsing logic as internal/gemini/client.go:parseAssignmentsResponse.
+func parseLocalAssignmentsResponse(responseText string, items []models.CheckboxItem) ([]models.CheckboxAssignment, error) {
+	responseText = strings.TrimSpace(responseText)
+	responseText = strings.TrimPrefix(responseText, "```json")
+	responseText = strings.TrimPrefix(responseText, "```")
+	responseText = strings.TrimSuffix(responseText, "```")
+	responseText = strings.TrimSpace(responseText)
+
+	// Try to find JSON array in the response.
+	jsonArrayRegex := regexp.MustCompile(`\[[\s\S]*\]`)
+	matches := jsonArrayRegex.FindString(responseText)
+	if matches != "" {
+		responseText = matches
+	}
+
+	var rawAssignments []struct {
+		Index    int     `json:"index"`
+		Assignee *string `json:"assignee"` // Pointer to handle null
+	}
+
+	if err := json.Unmarshal([]byte(responseText), &rawAssignments); err != nil {
+		return nil, fmt.Errorf("parse assignment response: %w", err)
+	}
+
+	// Map items by index for easy lookup.
+	itemMap := make(map[int]models.CheckboxItem)
+	for _, item := range items {
+		itemMap[item.Index] = item
+	}
+
+	// Build result — only include items with a non-empty assignee (FR-015).
+	var assignments []models.CheckboxAssignment
+	for _, raw := range rawAssignments {
+		item, ok := itemMap[raw.Index]
+		if !ok {
+			continue
+		}
+
+		assignee := ""
+		if raw.Assignee != nil {
+			assignee = *raw.Assignee
+		}
+
+		if assignee != "" {
+			assignments = append(assignments, models.CheckboxAssignment{
+				Index:    raw.Index,
+				Text:     item.Text,
+				Assignee: assignee,
+			})
+		}
+	}
+
+	return assignments, nil
+}

--- a/internal/ollama/assigner_test.go
+++ b/internal/ollama/assigner_test.go
@@ -1,0 +1,199 @@
+package ollama
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/jflowers/gcal-organizer/pkg/models"
+)
+
+func TestAssigner_SingleAssignee(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		resp := generateResponse{
+			Response: `[{"index": 0, "assignee": "Jay"}]`,
+			Done:     true,
+		}
+		json.NewEncoder(w).Encode(resp)
+	}))
+	defer srv.Close()
+
+	client := NewClient(srv.URL, 10)
+	assigner := NewAssigner(client, "granite3.2:8b")
+
+	items := []models.CheckboxItem{
+		{Index: 0, Text: "Jay will schedule the follow-up meeting"},
+	}
+
+	assignments, err := assigner.ExtractAssignees(context.Background(), items)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(assignments) != 1 {
+		t.Fatalf("expected 1 assignment, got %d", len(assignments))
+	}
+	if assignments[0].Assignee != "Jay" {
+		t.Errorf("expected assignee 'Jay', got %q", assignments[0].Assignee)
+	}
+	if assignments[0].Text != "Jay will schedule the follow-up meeting" {
+		t.Errorf("expected text preserved, got %q", assignments[0].Text)
+	}
+}
+
+func TestAssigner_GroupAssigneeReturnsNull(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		resp := generateResponse{
+			Response: `[{"index": 0, "assignee": null}]`,
+			Done:     true,
+		}
+		json.NewEncoder(w).Encode(resp)
+	}))
+	defer srv.Close()
+
+	client := NewClient(srv.URL, 10)
+	assigner := NewAssigner(client, "granite3.2:8b")
+
+	items := []models.CheckboxItem{
+		{Index: 0, Text: "The team will discuss the proposal"},
+	}
+
+	assignments, err := assigner.ExtractAssignees(context.Background(), items)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	// Null assignees are omitted from results
+	if len(assignments) != 0 {
+		t.Errorf("expected 0 assignments for group task, got %d", len(assignments))
+	}
+}
+
+func TestAssigner_AmbiguousReturnsNull(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		resp := generateResponse{
+			Response: `[{"index": 0, "assignee": null}]`,
+			Done:     true,
+		}
+		json.NewEncoder(w).Encode(resp)
+	}))
+	defer srv.Close()
+
+	client := NewClient(srv.URL, 10)
+	assigner := NewAssigner(client, "granite3.2:8b")
+
+	items := []models.CheckboxItem{
+		{Index: 0, Text: "Someone should check the report"},
+	}
+
+	assignments, err := assigner.ExtractAssignees(context.Background(), items)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(assignments) != 0 {
+		t.Errorf("expected 0 assignments for ambiguous task, got %d", len(assignments))
+	}
+}
+
+func TestAssigner_MultipleMixed(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		resp := generateResponse{
+			Response: `[
+				{"index": 0, "assignee": "Jay"},
+				{"index": 1, "assignee": null},
+				{"index": 2, "assignee": "Sarah"}
+			]`,
+			Done: true,
+		}
+		json.NewEncoder(w).Encode(resp)
+	}))
+	defer srv.Close()
+
+	client := NewClient(srv.URL, 10)
+	assigner := NewAssigner(client, "granite3.2:8b")
+
+	items := []models.CheckboxItem{
+		{Index: 0, Text: "Jay will schedule the meeting"},
+		{Index: 1, Text: "The team will review"},
+		{Index: 2, Text: "Sarah will send the email"},
+	}
+
+	assignments, err := assigner.ExtractAssignees(context.Background(), items)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(assignments) != 2 {
+		t.Fatalf("expected 2 assignments, got %d", len(assignments))
+	}
+	if assignments[0].Assignee != "Jay" {
+		t.Errorf("expected first assignee 'Jay', got %q", assignments[0].Assignee)
+	}
+	if assignments[1].Assignee != "Sarah" {
+		t.Errorf("expected second assignee 'Sarah', got %q", assignments[1].Assignee)
+	}
+}
+
+func TestAssigner_EmptyItems(t *testing.T) {
+	client := NewClient("http://unused", 10)
+	assigner := NewAssigner(client, "granite3.2:8b")
+
+	assignments, err := assigner.ExtractAssignees(context.Background(), nil)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if assignments != nil {
+		t.Errorf("expected nil for empty items, got %v", assignments)
+	}
+}
+
+func TestAssigner_MalformedResponseRetry(t *testing.T) {
+	callCount := 0
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		callCount++
+		var respText string
+		if callCount == 1 {
+			respText = "not json"
+		} else {
+			respText = `[{"index": 0, "assignee": "Jay"}]`
+		}
+		resp := generateResponse{Response: respText, Done: true}
+		json.NewEncoder(w).Encode(resp)
+	}))
+	defer srv.Close()
+
+	client := NewClient(srv.URL, 10)
+	assigner := NewAssigner(client, "granite3.2:8b")
+
+	items := []models.CheckboxItem{
+		{Index: 0, Text: "Jay will do it"},
+	}
+
+	assignments, err := assigner.ExtractAssignees(context.Background(), items)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(assignments) != 1 {
+		t.Fatalf("expected 1 assignment after retry, got %d", len(assignments))
+	}
+	if callCount != 2 {
+		t.Errorf("expected 2 attempts, got %d", callCount)
+	}
+}
+
+func TestAssigner_NetworkError_HardStop(t *testing.T) {
+	client := NewClient("http://127.0.0.1:1", 2)
+	assigner := NewAssigner(client, "granite3.2:8b")
+
+	items := []models.CheckboxItem{
+		{Index: 0, Text: "Jay will do it"},
+	}
+
+	_, err := assigner.ExtractAssignees(context.Background(), items)
+	if err == nil {
+		t.Fatal("expected error for network failure")
+	}
+	if errors.Is(err, ErrMalformedResponse) {
+		t.Error("network error should not be wrapped as ErrMalformedResponse")
+	}
+}

--- a/internal/ollama/client.go
+++ b/internal/ollama/client.go
@@ -1,0 +1,217 @@
+// Package ollama provides a raw HTTP client for the Ollama REST API.
+// All communication uses net/http (FR-012: no SDK dependency).
+// Design follows the proven Dewey llm.go pattern: stream=false, response
+// body cap, context propagation, and 30-second model availability cache.
+package ollama
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+	"sync"
+	"time"
+)
+
+// Sentinel errors for specific Ollama failure conditions.
+var (
+	// ErrOllamaUnavailable indicates Ollama is configured but not reachable.
+	// The pipeline must hard-stop (FR-009).
+	ErrOllamaUnavailable = errors.New("ollama is configured but not available")
+
+	// ErrModelNotAvailable indicates a required model is not pulled.
+	ErrModelNotAvailable = errors.New("required ollama model is not available")
+
+	// ErrMalformedResponse indicates the model returned unparseable output
+	// after the retry attempt.
+	ErrMalformedResponse = errors.New("ollama model returned malformed response")
+)
+
+// maxResponseBytes caps the response body size to prevent unbounded memory
+// allocation from unexpectedly large responses (same as Dewey: 50 MB).
+const maxResponseBytes = 50 * 1024 * 1024
+
+// generateRequest is the JSON body for POST /api/generate.
+type generateRequest struct {
+	Model  string `json:"model"`
+	Prompt string `json:"prompt"`
+	Stream bool   `json:"stream"`
+}
+
+// generateResponse is the JSON response from POST /api/generate (stream=false).
+type generateResponse struct {
+	Response string `json:"response"`
+	Done     bool   `json:"done"`
+}
+
+// tagsResponse is the JSON response from GET /api/tags.
+type tagsResponse struct {
+	Models []modelInfo `json:"models"`
+}
+
+// modelInfo represents a single model entry from /api/tags.
+type modelInfo struct {
+	Name string `json:"name"`
+}
+
+// Client provides low-level HTTP communication with the Ollama API.
+// All higher-level components (SensitivityClassifier, TaskAssigner,
+// DecisionExtractor) use Client for HTTP operations.
+//
+// Design decision: Single client shared across components rather than
+// each component managing its own HTTP client. This centralizes timeout
+// configuration, health checking, and model availability caching.
+type Client struct {
+	baseURL string
+	client  *http.Client
+
+	// Model availability cache (same pattern as Dewey's OllamaSynthesizer).
+	mu            sync.RWMutex
+	modelCache    map[string]bool
+	lastCheck     time.Time
+	checkInterval time.Duration
+}
+
+// NewClient creates a Client that connects to the Ollama API at the given
+// endpoint with the specified timeout (in seconds) for generation requests.
+func NewClient(endpoint string, timeoutSeconds int) *Client {
+	return &Client{
+		baseURL: strings.TrimRight(endpoint, "/"),
+		client: &http.Client{
+			Timeout: time.Duration(timeoutSeconds) * time.Second,
+		},
+		modelCache:    make(map[string]bool),
+		checkInterval: 30 * time.Second,
+	}
+}
+
+// Generate sends a prompt to the specified model via POST /api/generate
+// and returns the generated text. Uses stream=false for single-response mode.
+// The response body is capped at 50 MB to prevent unbounded memory allocation.
+func (c *Client) Generate(ctx context.Context, model, prompt string) (string, error) {
+	reqBody := generateRequest{
+		Model:  model,
+		Prompt: prompt,
+		Stream: false,
+	}
+
+	bodyBytes, err := json.Marshal(reqBody)
+	if err != nil {
+		return "", fmt.Errorf("marshal generate request: %w", err)
+	}
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, c.baseURL+"/api/generate", strings.NewReader(string(bodyBytes)))
+	if err != nil {
+		return "", fmt.Errorf("create generate request: %w", err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err := c.client.Do(req)
+	if err != nil {
+		return "", fmt.Errorf("ollama generate request failed: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return "", fmt.Errorf("ollama generate returned HTTP %d", resp.StatusCode)
+	}
+
+	// Cap response body to prevent unbounded memory allocation.
+	limited := io.LimitReader(resp.Body, maxResponseBytes)
+	data, err := io.ReadAll(limited)
+	if err != nil {
+		return "", fmt.Errorf("read generate response: %w", err)
+	}
+
+	var genResp generateResponse
+	if err := json.Unmarshal(data, &genResp); err != nil {
+		return "", fmt.Errorf("%w: %v", ErrMalformedResponse, err)
+	}
+
+	return genResp.Response, nil
+}
+
+// HealthCheck reports whether Ollama is reachable by sending GET /api/tags
+// with a 2-second timeout. Returns true if the response is HTTP 200.
+func (c *Client) HealthCheck() bool {
+	healthClient := &http.Client{Timeout: 2 * time.Second}
+	resp, err := healthClient.Get(c.baseURL + "/api/tags")
+	if err != nil {
+		return false
+	}
+	defer resp.Body.Close()
+	return resp.StatusCode == http.StatusOK
+}
+
+// ModelAvailable reports whether the specified model is available in the
+// Ollama instance by querying GET /api/tags. Caches results for 30 seconds
+// to avoid redundant HTTP calls during pipeline runs.
+func (c *Client) ModelAvailable(model string) bool {
+	c.mu.RLock()
+	if time.Since(c.lastCheck) < c.checkInterval {
+		// Check exact match and :latest suffix match in cache.
+		if c.modelCache[model] || c.modelCache[model+":latest"] {
+			c.mu.RUnlock()
+			return true
+		}
+		// Model not found in a fresh cache — it's genuinely missing.
+		if len(c.modelCache) > 0 {
+			c.mu.RUnlock()
+			return false
+		}
+	}
+	c.mu.RUnlock()
+
+	// Cache miss or expired — refresh.
+	models, err := c.ListModels()
+	if err != nil {
+		return false
+	}
+
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	// Rebuild cache.
+	c.modelCache = make(map[string]bool)
+	for _, m := range models {
+		c.modelCache[m] = true
+	}
+	c.lastCheck = time.Now()
+
+	// Check with :latest suffix matching: "granite-guardian" matches
+	// "granite-guardian:latest".
+	return c.modelCache[model] || c.modelCache[model+":latest"]
+}
+
+// ListModels returns the names of all models available in the Ollama instance.
+func (c *Client) ListModels() ([]string, error) {
+	resp, err := c.client.Get(c.baseURL + "/api/tags")
+	if err != nil {
+		return nil, fmt.Errorf("list models: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("list models returned HTTP %d", resp.StatusCode)
+	}
+
+	limited := io.LimitReader(resp.Body, maxResponseBytes)
+	data, err := io.ReadAll(limited)
+	if err != nil {
+		return nil, fmt.Errorf("read models response: %w", err)
+	}
+
+	var tags tagsResponse
+	if err := json.Unmarshal(data, &tags); err != nil {
+		return nil, fmt.Errorf("parse models response: %w", err)
+	}
+
+	names := make([]string, len(tags.Models))
+	for i, m := range tags.Models {
+		names[i] = m.Name
+	}
+	return names, nil
+}

--- a/internal/ollama/client_test.go
+++ b/internal/ollama/client_test.go
@@ -1,0 +1,209 @@
+package ollama
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestGenerate_Success(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost || r.URL.Path != "/api/generate" {
+			t.Errorf("unexpected request: %s %s", r.Method, r.URL.Path)
+		}
+		resp := generateResponse{Response: "Hello, world!", Done: true}
+		json.NewEncoder(w).Encode(resp)
+	}))
+	defer srv.Close()
+
+	client := NewClient(srv.URL, 10)
+	result, err := client.Generate(context.Background(), "test-model", "say hello")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if result != "Hello, world!" {
+		t.Errorf("expected 'Hello, world!', got %q", result)
+	}
+}
+
+func TestGenerate_HTTP500(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+	}))
+	defer srv.Close()
+
+	client := NewClient(srv.URL, 10)
+	_, err := client.Generate(context.Background(), "test-model", "say hello")
+	if err == nil {
+		t.Fatal("expected error for HTTP 500")
+	}
+	if !strings.Contains(err.Error(), "HTTP 500") {
+		t.Errorf("expected HTTP 500 in error, got: %v", err)
+	}
+}
+
+func TestGenerate_MalformedJSON(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Write([]byte("not json"))
+	}))
+	defer srv.Close()
+
+	client := NewClient(srv.URL, 10)
+	_, err := client.Generate(context.Background(), "test-model", "say hello")
+	if err == nil {
+		t.Fatal("expected error for malformed JSON")
+	}
+	if !strings.Contains(err.Error(), "malformed response") {
+		t.Errorf("expected 'malformed response' in error, got: %v", err)
+	}
+}
+
+func TestGenerate_ContextCancellation(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		time.Sleep(5 * time.Second)
+		resp := generateResponse{Response: "too late", Done: true}
+		json.NewEncoder(w).Encode(resp)
+	}))
+	defer srv.Close()
+
+	client := NewClient(srv.URL, 30)
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel() // Cancel immediately
+
+	_, err := client.Generate(ctx, "test-model", "say hello")
+	if err == nil {
+		t.Fatal("expected error for cancelled context")
+	}
+}
+
+func TestGenerate_UnreachableServer(t *testing.T) {
+	client := NewClient("http://127.0.0.1:1", 2)
+	_, err := client.Generate(context.Background(), "test-model", "say hello")
+	if err == nil {
+		t.Fatal("expected error for unreachable server")
+	}
+}
+
+func TestHealthCheck_Success(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/api/tags" {
+			t.Errorf("unexpected path: %s", r.URL.Path)
+		}
+		w.WriteHeader(http.StatusOK)
+		json.NewEncoder(w).Encode(tagsResponse{Models: []modelInfo{}})
+	}))
+	defer srv.Close()
+
+	client := NewClient(srv.URL, 10)
+	if !client.HealthCheck() {
+		t.Error("expected HealthCheck to return true")
+	}
+}
+
+func TestHealthCheck_Unreachable(t *testing.T) {
+	client := NewClient("http://127.0.0.1:1", 2)
+	if client.HealthCheck() {
+		t.Error("expected HealthCheck to return false for unreachable server")
+	}
+}
+
+func TestModelAvailable_Present(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		json.NewEncoder(w).Encode(tagsResponse{
+			Models: []modelInfo{
+				{Name: "granite-guardian:latest"},
+				{Name: "granite3.2:8b"},
+			},
+		})
+	}))
+	defer srv.Close()
+
+	client := NewClient(srv.URL, 10)
+
+	// Exact match
+	if !client.ModelAvailable("granite3.2:8b") {
+		t.Error("expected granite3.2:8b to be available")
+	}
+
+	// :latest suffix matching
+	if !client.ModelAvailable("granite-guardian") {
+		t.Error("expected granite-guardian to match granite-guardian:latest")
+	}
+}
+
+func TestModelAvailable_Missing(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		json.NewEncoder(w).Encode(tagsResponse{
+			Models: []modelInfo{
+				{Name: "other-model:latest"},
+			},
+		})
+	}))
+	defer srv.Close()
+
+	client := NewClient(srv.URL, 10)
+	if client.ModelAvailable("granite-guardian") {
+		t.Error("expected granite-guardian to be unavailable")
+	}
+}
+
+func TestModelAvailable_CacheHit(t *testing.T) {
+	callCount := 0
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		callCount++
+		json.NewEncoder(w).Encode(tagsResponse{
+			Models: []modelInfo{
+				{Name: "granite-guardian:latest"},
+			},
+		})
+	}))
+	defer srv.Close()
+
+	client := NewClient(srv.URL, 10)
+
+	// First call populates cache
+	client.ModelAvailable("granite-guardian")
+	firstCount := callCount
+
+	// Second call should use cache (no additional HTTP call)
+	client.ModelAvailable("granite-guardian")
+	if callCount != firstCount {
+		t.Errorf("expected cache hit (no additional HTTP call), but got %d total calls", callCount)
+	}
+}
+
+func TestListModels_Success(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		json.NewEncoder(w).Encode(tagsResponse{
+			Models: []modelInfo{
+				{Name: "model-a"},
+				{Name: "model-b:latest"},
+			},
+		})
+	}))
+	defer srv.Close()
+
+	client := NewClient(srv.URL, 10)
+	models, err := client.ListModels()
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(models) != 2 {
+		t.Fatalf("expected 2 models, got %d", len(models))
+	}
+	if models[0] != "model-a" || models[1] != "model-b:latest" {
+		t.Errorf("unexpected models: %v", models)
+	}
+}
+
+func TestListModels_Error(t *testing.T) {
+	client := NewClient("http://127.0.0.1:1", 2)
+	_, err := client.ListModels()
+	if err == nil {
+		t.Fatal("expected error for unreachable server")
+	}
+}

--- a/internal/ollama/decisions.go
+++ b/internal/ollama/decisions.go
@@ -1,0 +1,146 @@
+package ollama
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"regexp"
+	"strings"
+
+	"github.com/jflowers/gcal-organizer/pkg/models"
+)
+
+// DecisionExtractor extracts structured decisions from meeting transcripts
+// using a local AI model. Used in local-only mode as a replacement for
+// the cloud-based Gemini extraction.
+type DecisionExtractor interface {
+	// ExtractDecisions analyzes a transcript and returns categorized decisions
+	// (made, deferred, open) with text, timestamp, and context fields.
+	ExtractDecisions(ctx context.Context, transcriptText string) ([]models.Decision, error)
+}
+
+// LocalDecisionExtractor implements DecisionExtractor using a local Ollama model.
+type LocalDecisionExtractor struct {
+	client *Client
+	model  string
+}
+
+// NewDecisionExtractor creates a LocalDecisionExtractor that uses the specified
+// model via the given Ollama client.
+func NewDecisionExtractor(client *Client, model string) *LocalDecisionExtractor {
+	return &LocalDecisionExtractor{
+		client: client,
+		model:  model,
+	}
+}
+
+// ExtractDecisions analyzes a transcript and returns categorized decisions.
+// Reuses the same prompt as the Gemini implementation (model-agnostic).
+// FR-017: produces same three categories (made, deferred, open).
+// Retries once on malformed response, hard-stops on network errors.
+func (d *LocalDecisionExtractor) ExtractDecisions(ctx context.Context, transcriptText string) ([]models.Decision, error) {
+	if transcriptText == "" {
+		return nil, nil
+	}
+
+	// Same prompt as internal/gemini/client.go:ExtractDecisions
+	prompt := fmt.Sprintf(`You are a meeting decision extraction assistant. Analyze the following meeting transcript and extract all decisions into three categories:
+
+1. "made" — Decisions that were explicitly agreed upon or committed to
+2. "deferred" — Decisions that were explicitly postponed or tabled for later
+3. "open" — Topics discussed but left unresolved, needing further discussion
+
+For each decision, provide:
+- "category": one of "made", "deferred", or "open"
+- "text": a clear, concise description of the decision (one sentence)
+- "timestamp": the HH:MM timestamp from the transcript where this was discussed (or empty string if not identifiable)
+- "context": a brief excerpt from the transcript providing context (or empty string)
+
+Return ONLY a JSON array. No other text.
+
+Example response:
+[
+  {"category": "made", "text": "Team will adopt GitHub Actions for CI/CD", "timestamp": "12:34", "context": "After discussing three options, team voted unanimously"},
+  {"category": "deferred", "text": "Budget allocation for Q3", "timestamp": "13:15", "context": "Waiting for finance team input"},
+  {"category": "open", "text": "Whether to migrate to new API version", "timestamp": "13:45", "context": "Need performance benchmarks first"}
+]
+
+If no decisions are found, return an empty array: []
+
+Transcript:
+%s`, transcriptText)
+
+	var lastErr error
+	for attempt := 0; attempt < 2; attempt++ {
+		response, err := d.client.Generate(ctx, d.model, prompt)
+		if err != nil {
+			// Network/timeout errors: hard-stop immediately (FR-009).
+			return nil, fmt.Errorf("local decision extraction failed: %w", err)
+		}
+
+		decisions, parseErr := parseLocalDecisionsResponse(response)
+		if parseErr != nil {
+			lastErr = parseErr
+			continue // Retry on malformed response
+		}
+		return decisions, nil
+	}
+
+	return nil, fmt.Errorf("%w: %v", ErrMalformedResponse, lastErr)
+}
+
+// parseLocalDecisionsResponse parses the JSON array response from the local model.
+// Same parsing logic as internal/gemini/client.go:parseDecisionsResponse.
+func parseLocalDecisionsResponse(responseText string) ([]models.Decision, error) {
+	responseText = strings.TrimSpace(responseText)
+	responseText = strings.TrimPrefix(responseText, "```json")
+	responseText = strings.TrimPrefix(responseText, "```")
+	responseText = strings.TrimSuffix(responseText, "```")
+	responseText = strings.TrimSpace(responseText)
+
+	// Try to find JSON array in the response.
+	jsonArrayRegex := regexp.MustCompile(`\[[\s\S]*\]`)
+	matches := jsonArrayRegex.FindString(responseText)
+	if matches != "" {
+		responseText = matches
+	}
+
+	var rawDecisions []struct {
+		Category  string `json:"category"`
+		Text      string `json:"text"`
+		Timestamp string `json:"timestamp"`
+		Context   string `json:"context"`
+	}
+
+	if err := json.Unmarshal([]byte(responseText), &rawDecisions); err != nil {
+		return nil, fmt.Errorf("parse decisions response: %w", err)
+	}
+
+	validCategories := map[string]bool{
+		"made":     true,
+		"deferred": true,
+		"open":     true,
+	}
+
+	var decisions []models.Decision
+	for _, raw := range rawDecisions {
+		text := strings.TrimSpace(raw.Text)
+		if text == "" {
+			continue
+		}
+
+		category := strings.ToLower(strings.TrimSpace(raw.Category))
+		if !validCategories[category] {
+			category = "open"
+		}
+
+		decisions = append(decisions, models.Decision{
+			Category:  category,
+			Text:      text,
+			Timestamp: strings.TrimSpace(raw.Timestamp),
+			Context:   strings.TrimSpace(raw.Context),
+		})
+	}
+
+	return decisions, nil
+}

--- a/internal/ollama/decisions_test.go
+++ b/internal/ollama/decisions_test.go
@@ -1,0 +1,186 @@
+package ollama
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+func TestDecisionExtractor_MadeDeferredOpen(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		resp := generateResponse{
+			Response: `[
+				{"category": "made", "text": "Adopt GitHub Actions", "timestamp": "12:34", "context": "Team voted"},
+				{"category": "deferred", "text": "Budget allocation", "timestamp": "13:15", "context": "Waiting for finance"},
+				{"category": "open", "text": "API migration", "timestamp": "13:45", "context": "Need benchmarks"}
+			]`,
+			Done: true,
+		}
+		json.NewEncoder(w).Encode(resp)
+	}))
+	defer srv.Close()
+
+	client := NewClient(srv.URL, 10)
+	extractor := NewDecisionExtractor(client, "granite3.2:8b")
+
+	decisions, err := extractor.ExtractDecisions(context.Background(), "Meeting transcript here...")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(decisions) != 3 {
+		t.Fatalf("expected 3 decisions, got %d", len(decisions))
+	}
+
+	// Verify all three categories present
+	categories := map[string]bool{}
+	for _, d := range decisions {
+		categories[d.Category] = true
+	}
+	for _, cat := range []string{"made", "deferred", "open"} {
+		if !categories[cat] {
+			t.Errorf("expected category %q in results", cat)
+		}
+	}
+
+	// Verify first decision
+	if decisions[0].Text != "Adopt GitHub Actions" {
+		t.Errorf("expected text 'Adopt GitHub Actions', got %q", decisions[0].Text)
+	}
+	if decisions[0].Timestamp != "12:34" {
+		t.Errorf("expected timestamp '12:34', got %q", decisions[0].Timestamp)
+	}
+}
+
+func TestDecisionExtractor_EmptyTranscript(t *testing.T) {
+	client := NewClient("http://unused", 10)
+	extractor := NewDecisionExtractor(client, "granite3.2:8b")
+
+	decisions, err := extractor.ExtractDecisions(context.Background(), "")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if decisions != nil {
+		t.Errorf("expected nil for empty transcript, got %v", decisions)
+	}
+}
+
+func TestDecisionExtractor_MalformedResponseRetrySuccess(t *testing.T) {
+	callCount := 0
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		callCount++
+		var respText string
+		if callCount == 1 {
+			respText = "not json at all"
+		} else {
+			respText = `[{"category": "made", "text": "Decision after retry", "timestamp": "", "context": ""}]`
+		}
+		resp := generateResponse{Response: respText, Done: true}
+		json.NewEncoder(w).Encode(resp)
+	}))
+	defer srv.Close()
+
+	client := NewClient(srv.URL, 10)
+	extractor := NewDecisionExtractor(client, "granite3.2:8b")
+
+	decisions, err := extractor.ExtractDecisions(context.Background(), "Some transcript")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(decisions) != 1 {
+		t.Fatalf("expected 1 decision after retry, got %d", len(decisions))
+	}
+	if callCount != 2 {
+		t.Errorf("expected 2 attempts, got %d", callCount)
+	}
+}
+
+func TestDecisionExtractor_MalformedResponseRetryFail(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		resp := generateResponse{Response: "not json", Done: true}
+		json.NewEncoder(w).Encode(resp)
+	}))
+	defer srv.Close()
+
+	client := NewClient(srv.URL, 10)
+	extractor := NewDecisionExtractor(client, "granite3.2:8b")
+
+	_, err := extractor.ExtractDecisions(context.Background(), "Some transcript")
+	if err == nil {
+		t.Fatal("expected error after 2 failed attempts")
+	}
+	if !errors.Is(err, ErrMalformedResponse) {
+		t.Errorf("expected ErrMalformedResponse, got: %v", err)
+	}
+}
+
+func TestDecisionExtractor_NetworkError_HardStop(t *testing.T) {
+	client := NewClient("http://127.0.0.1:1", 2)
+	extractor := NewDecisionExtractor(client, "granite3.2:8b")
+
+	_, err := extractor.ExtractDecisions(context.Background(), "Some transcript")
+	if err == nil {
+		t.Fatal("expected error for network failure")
+	}
+	if errors.Is(err, ErrMalformedResponse) {
+		t.Error("network error should not be wrapped as ErrMalformedResponse")
+	}
+}
+
+func TestDecisionExtractor_AllThreeCategories(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		resp := generateResponse{
+			Response: `[
+				{"category": "made", "text": "Decision 1", "timestamp": "", "context": ""},
+				{"category": "deferred", "text": "Decision 2", "timestamp": "", "context": ""},
+				{"category": "open", "text": "Decision 3", "timestamp": "", "context": ""}
+			]`,
+			Done: true,
+		}
+		json.NewEncoder(w).Encode(resp)
+	}))
+	defer srv.Close()
+
+	client := NewClient(srv.URL, 10)
+	extractor := NewDecisionExtractor(client, "granite3.2:8b")
+
+	decisions, err := extractor.ExtractDecisions(context.Background(), "Some transcript")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(decisions) != 3 {
+		t.Fatalf("expected 3 decisions, got %d", len(decisions))
+	}
+
+	wantCategories := []string{"made", "deferred", "open"}
+	for i, want := range wantCategories {
+		if decisions[i].Category != want {
+			t.Errorf("decision %d: expected category %q, got %q", i, want, decisions[i].Category)
+		}
+	}
+}
+
+func TestParseLocalDecisionsResponse_InvalidCategory(t *testing.T) {
+	decisions, err := parseLocalDecisionsResponse(`[{"category": "unknown", "text": "Test", "timestamp": "", "context": ""}]`)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(decisions) != 1 {
+		t.Fatalf("expected 1 decision, got %d", len(decisions))
+	}
+	if decisions[0].Category != "open" {
+		t.Errorf("expected unknown category to default to 'open', got %q", decisions[0].Category)
+	}
+}
+
+func TestParseLocalDecisionsResponse_EmptyText(t *testing.T) {
+	decisions, err := parseLocalDecisionsResponse(`[{"category": "made", "text": "", "timestamp": "", "context": ""}]`)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(decisions) != 0 {
+		t.Errorf("expected empty text to be filtered out, got %d decisions", len(decisions))
+	}
+}

--- a/internal/ollama/guardian.go
+++ b/internal/ollama/guardian.go
@@ -1,0 +1,152 @@
+package ollama
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"strings"
+
+	"github.com/jflowers/gcal-organizer/pkg/models"
+)
+
+// defaultMaxTranscriptChars is the default maximum transcript length in
+// characters before truncation. Approximately 6000 tokens for granite-guardian.
+const defaultMaxTranscriptChars = 24000
+
+// SensitivityClassifier classifies transcript content for sensitivity
+// before any processing occurs. Implementations must be safe for
+// concurrent use.
+type SensitivityClassifier interface {
+	// Classify analyzes a transcript and returns a sensitivity determination.
+	// Returns an error if the classification fails (model unavailable,
+	// malformed response after retry, timeout).
+	Classify(ctx context.Context, transcript string) (*models.SensitivityResult, error)
+}
+
+// Guardian implements SensitivityClassifier using the granite-guardian model
+// via the Ollama API.
+type Guardian struct {
+	client           *Client
+	model            string
+	maxTranscriptLen int
+}
+
+// NewGuardian creates a Guardian sensitivity classifier that uses the specified
+// model via the given Ollama client.
+func NewGuardian(client *Client, model string) *Guardian {
+	return &Guardian{
+		client:           client,
+		model:            model,
+		maxTranscriptLen: defaultMaxTranscriptChars,
+	}
+}
+
+// sensitivityPrompt is the prompt template for sensitivity classification.
+// Categories and rules from research.md section 3.
+const sensitivityPrompt = `You are a workplace content sensitivity classifier. Analyze the following meeting transcript and determine if it contains sensitive content that should not be processed by cloud AI services or written to external files.
+
+Classify the transcript into one of these categories:
+- "hr": Performance reviews, disciplinary actions, employee complaints, accommodation requests, hiring/firing discussions about specific individuals
+- "legal": Legal proceedings, compliance investigations, regulatory matters, contracts under negotiation, litigation strategy
+- "financial": Individual compensation discussions, salary negotiations, M&A discussions, confidential budget allocations
+- "health": Medical information, health accommodations, wellness concerns about specific individuals
+- "termination": Layoff planning, termination decisions, severance negotiations, reduction-in-force discussions
+- "none": No sensitive content detected
+
+Return your analysis as a JSON object with these fields:
+- "sensitive": boolean (true if the transcript contains sensitive content)
+- "category": string (one of: hr, legal, financial, health, termination, none)
+- "score": number between 0.0 and 1.0 (confidence in the classification)
+- "reasoning": string (brief explanation of why the content is or is not sensitive)
+
+Important rules:
+1. Err on the side of caution — if uncertain, classify as sensitive with a moderate score
+2. Focus on content about SPECIFIC INDIVIDUALS, not general policy discussions
+3. A meeting about "updating the PTO policy" is NOT sensitive; a meeting about "Sarah's excessive absences" IS sensitive
+4. Return ONLY the JSON object, no other text
+
+Transcript:
+%s`
+
+// validCategories defines the accepted sensitivity categories.
+var validCategories = map[string]bool{
+	"hr":          true,
+	"legal":       true,
+	"financial":   true,
+	"health":      true,
+	"termination": true,
+	"none":        true,
+}
+
+// Classify analyzes a transcript and returns a sensitivity determination.
+// Retries once on malformed response (total 2 attempts). Hard-stops on
+// network errors (FR-009).
+func (g *Guardian) Classify(ctx context.Context, transcript string) (*models.SensitivityResult, error) {
+	// Truncate transcript if it exceeds the max length.
+	transcript = g.truncateTranscript(transcript)
+
+	prompt := fmt.Sprintf(sensitivityPrompt, transcript)
+
+	var lastErr error
+	for attempt := 0; attempt < 2; attempt++ {
+		response, err := g.client.Generate(ctx, g.model, prompt)
+		if err != nil {
+			// Network/timeout errors: hard-stop immediately (FR-009).
+			return nil, fmt.Errorf("sensitivity classification failed: %w", err)
+		}
+
+		result, parseErr := parseSensitivityResponse(response)
+		if parseErr != nil {
+			lastErr = parseErr
+			continue // Retry on malformed response
+		}
+		return result, nil
+	}
+
+	return nil, fmt.Errorf("%w: %v", ErrMalformedResponse, lastErr)
+}
+
+// truncateTranscript truncates a transcript that exceeds the max length,
+// preserving the first 60% and last 40% with a separator.
+func (g *Guardian) truncateTranscript(transcript string) string {
+	if len(transcript) <= g.maxTranscriptLen {
+		return transcript
+	}
+
+	keepFirst := int(float64(g.maxTranscriptLen) * 0.6)
+	keepLast := g.maxTranscriptLen - keepFirst
+	separator := "\n\n[... transcript truncated ...]\n\n"
+
+	return transcript[:keepFirst] + separator + transcript[len(transcript)-keepLast:]
+}
+
+// parseSensitivityResponse parses the JSON response from the sensitivity model.
+// Strips markdown fences, validates category, and clamps score to [0.0, 1.0].
+func parseSensitivityResponse(response string) (*models.SensitivityResult, error) {
+	response = strings.TrimSpace(response)
+	response = strings.TrimPrefix(response, "```json")
+	response = strings.TrimPrefix(response, "```")
+	response = strings.TrimSuffix(response, "```")
+	response = strings.TrimSpace(response)
+
+	var result models.SensitivityResult
+	if err := json.Unmarshal([]byte(response), &result); err != nil {
+		return nil, fmt.Errorf("parse sensitivity response: %w", err)
+	}
+
+	// Validate category — default to "none" if unknown.
+	result.Category = strings.ToLower(strings.TrimSpace(result.Category))
+	if !validCategories[result.Category] {
+		result.Category = "none"
+	}
+
+	// Clamp score to [0.0, 1.0].
+	if result.Score < 0.0 {
+		result.Score = 0.0
+	}
+	if result.Score > 1.0 {
+		result.Score = 1.0
+	}
+
+	return &result, nil
+}

--- a/internal/ollama/guardian_test.go
+++ b/internal/ollama/guardian_test.go
@@ -1,0 +1,287 @@
+package ollama
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/jflowers/gcal-organizer/pkg/models"
+)
+
+func TestGuardian_ClassifySensitive(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		resp := generateResponse{
+			Response: `{"sensitive":true,"category":"hr","score":0.92,"reasoning":"Discussion about employee performance"}`,
+			Done:     true,
+		}
+		json.NewEncoder(w).Encode(resp)
+	}))
+	defer srv.Close()
+
+	client := NewClient(srv.URL, 10)
+	guardian := NewGuardian(client, "granite-guardian")
+
+	result, err := guardian.Classify(context.Background(), "We need to discuss Sarah's performance issues")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !result.Sensitive {
+		t.Error("expected Sensitive=true")
+	}
+	if result.Category != "hr" {
+		t.Errorf("expected category 'hr', got %q", result.Category)
+	}
+	if result.Score != 0.92 {
+		t.Errorf("expected score 0.92, got %f", result.Score)
+	}
+}
+
+func TestGuardian_ClassifyNotSensitive(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		resp := generateResponse{
+			Response: `{"sensitive":false,"category":"none","score":0.1,"reasoning":"Routine sprint planning"}`,
+			Done:     true,
+		}
+		json.NewEncoder(w).Encode(resp)
+	}))
+	defer srv.Close()
+
+	client := NewClient(srv.URL, 10)
+	guardian := NewGuardian(client, "granite-guardian")
+
+	result, err := guardian.Classify(context.Background(), "Sprint planning for next week")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if result.Sensitive {
+		t.Error("expected Sensitive=false")
+	}
+	if result.Category != "none" {
+		t.Errorf("expected category 'none', got %q", result.Category)
+	}
+}
+
+func TestGuardian_ThresholdBoundaryInclusive(t *testing.T) {
+	// Score exactly at threshold (0.70) should be treated as sensitive (FR-003: >=)
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		resp := generateResponse{
+			Response: `{"sensitive":true,"category":"legal","score":0.70,"reasoning":"Borderline case"}`,
+			Done:     true,
+		}
+		json.NewEncoder(w).Encode(resp)
+	}))
+	defer srv.Close()
+
+	client := NewClient(srv.URL, 10)
+	guardian := NewGuardian(client, "granite-guardian")
+
+	result, err := guardian.Classify(context.Background(), "Some transcript")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if result.Score != 0.70 {
+		t.Errorf("expected score 0.70, got %f", result.Score)
+	}
+	// The threshold comparison (>= 0.7) is done by the caller, not the classifier.
+	// The classifier just returns the result.
+}
+
+func TestGuardian_ThresholdBoundaryBelow(t *testing.T) {
+	// Score below threshold (0.69) should NOT be treated as sensitive
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		resp := generateResponse{
+			Response: `{"sensitive":false,"category":"none","score":0.69,"reasoning":"Below threshold"}`,
+			Done:     true,
+		}
+		json.NewEncoder(w).Encode(resp)
+	}))
+	defer srv.Close()
+
+	client := NewClient(srv.URL, 10)
+	guardian := NewGuardian(client, "granite-guardian")
+
+	result, err := guardian.Classify(context.Background(), "Some transcript")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if result.Score != 0.69 {
+		t.Errorf("expected score 0.69, got %f", result.Score)
+	}
+}
+
+func TestGuardian_MalformedResponseRetrySuccess(t *testing.T) {
+	callCount := 0
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		callCount++
+		var respText string
+		if callCount == 1 {
+			respText = "not valid json at all"
+		} else {
+			respText = `{"sensitive":false,"category":"none","score":0.1,"reasoning":"ok"}`
+		}
+		resp := generateResponse{Response: respText, Done: true}
+		json.NewEncoder(w).Encode(resp)
+	}))
+	defer srv.Close()
+
+	client := NewClient(srv.URL, 10)
+	guardian := NewGuardian(client, "granite-guardian")
+
+	result, err := guardian.Classify(context.Background(), "Some transcript")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if result.Category != "none" {
+		t.Errorf("expected category 'none', got %q", result.Category)
+	}
+	if callCount != 2 {
+		t.Errorf("expected 2 attempts, got %d", callCount)
+	}
+}
+
+func TestGuardian_MalformedResponseRetryFail(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		resp := generateResponse{Response: "not json", Done: true}
+		json.NewEncoder(w).Encode(resp)
+	}))
+	defer srv.Close()
+
+	client := NewClient(srv.URL, 10)
+	guardian := NewGuardian(client, "granite-guardian")
+
+	_, err := guardian.Classify(context.Background(), "Some transcript")
+	if err == nil {
+		t.Fatal("expected error after 2 failed attempts")
+	}
+	if !errors.Is(err, ErrMalformedResponse) {
+		t.Errorf("expected ErrMalformedResponse, got: %v", err)
+	}
+}
+
+func TestGuardian_NetworkError_HardStop(t *testing.T) {
+	client := NewClient("http://127.0.0.1:1", 2)
+	guardian := NewGuardian(client, "granite-guardian")
+
+	_, err := guardian.Classify(context.Background(), "Some transcript")
+	if err == nil {
+		t.Fatal("expected error for network failure")
+	}
+	// Network errors should NOT retry — immediate hard-stop
+	if errors.Is(err, ErrMalformedResponse) {
+		t.Error("network error should not be wrapped as ErrMalformedResponse")
+	}
+}
+
+func TestGuardian_TranscriptTruncation(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// Parse the request to check the prompt
+		var req generateRequest
+		json.NewDecoder(r.Body).Decode(&req)
+
+		// Verify truncation happened
+		if !strings.Contains(req.Prompt, "[... transcript truncated ...]") {
+			t.Error("expected truncation marker in prompt")
+		}
+
+		resp := generateResponse{
+			Response: `{"sensitive":false,"category":"none","score":0.1,"reasoning":"truncated"}`,
+			Done:     true,
+		}
+		json.NewEncoder(w).Encode(resp)
+	}))
+	defer srv.Close()
+
+	client := NewClient(srv.URL, 10)
+	guardian := NewGuardian(client, "granite-guardian")
+	guardian.maxTranscriptLen = 100 // Set very low for testing
+
+	longTranscript := strings.Repeat("x", 200)
+	result, err := guardian.Classify(context.Background(), longTranscript)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if result == nil {
+		t.Fatal("expected non-nil result")
+	}
+}
+
+func TestGuardian_AllCategories(t *testing.T) {
+	categories := []string{"hr", "legal", "financial", "health", "termination", "none"}
+
+	for _, cat := range categories {
+		t.Run(cat, func(t *testing.T) {
+			srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				result := models.SensitivityResult{
+					Sensitive: cat != "none",
+					Category:  cat,
+					Score:     0.85,
+					Reasoning: "test",
+				}
+				respJSON, _ := json.Marshal(result)
+				resp := generateResponse{Response: string(respJSON), Done: true}
+				json.NewEncoder(w).Encode(resp)
+			}))
+			defer srv.Close()
+
+			client := NewClient(srv.URL, 10)
+			guardian := NewGuardian(client, "granite-guardian")
+
+			result, err := guardian.Classify(context.Background(), "test transcript")
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if result.Category != cat {
+				t.Errorf("expected category %q, got %q", cat, result.Category)
+			}
+		})
+	}
+}
+
+func TestParseSensitivityResponse_ScoreClamping(t *testing.T) {
+	tests := []struct {
+		name      string
+		input     string
+		wantScore float64
+	}{
+		{"negative score", `{"sensitive":false,"category":"none","score":-0.5,"reasoning":"test"}`, 0.0},
+		{"score above 1", `{"sensitive":true,"category":"hr","score":1.5,"reasoning":"test"}`, 1.0},
+		{"normal score", `{"sensitive":true,"category":"hr","score":0.85,"reasoning":"test"}`, 0.85},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result, err := parseSensitivityResponse(tt.input)
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if result.Score != tt.wantScore {
+				t.Errorf("expected score %f, got %f", tt.wantScore, result.Score)
+			}
+		})
+	}
+}
+
+func TestParseSensitivityResponse_UnknownCategory(t *testing.T) {
+	result, err := parseSensitivityResponse(`{"sensitive":false,"category":"unknown_cat","score":0.5,"reasoning":"test"}`)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if result.Category != "none" {
+		t.Errorf("expected unknown category to default to 'none', got %q", result.Category)
+	}
+}
+
+func TestParseSensitivityResponse_MarkdownFences(t *testing.T) {
+	input := "```json\n{\"sensitive\":false,\"category\":\"none\",\"score\":0.1,\"reasoning\":\"test\"}\n```"
+	result, err := parseSensitivityResponse(input)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if result.Category != "none" {
+		t.Errorf("expected category 'none', got %q", result.Category)
+	}
+}

--- a/internal/organizer/organizer.go
+++ b/internal/organizer/organizer.go
@@ -12,6 +12,7 @@ import (
 	"github.com/jflowers/gcal-organizer/internal/docs"
 	"github.com/jflowers/gcal-organizer/internal/drive"
 	"github.com/jflowers/gcal-organizer/internal/logging"
+	"github.com/jflowers/gcal-organizer/internal/ollama"
 	"github.com/jflowers/gcal-organizer/pkg/models"
 )
 
@@ -66,6 +67,12 @@ type Stats struct {
 	DecisionsExportFailed int
 	Skipped               int
 	Errors                int
+
+	// SensitivitySkipped counts transcripts skipped due to sensitivity classification.
+	SensitivitySkipped int
+
+	// SensitivityProcessed counts transcripts that passed the sensitivity gate.
+	SensitivityProcessed int
 }
 
 // Organizer orchestrates all the services.
@@ -78,6 +85,10 @@ type Organizer struct {
 	stats               Stats
 	notesDocIDs         map[string]bool                      // Google Doc IDs with "Notes" attachments
 	decisionDocContexts map[string]models.DecisionDocContext // Google Doc IDs for decision extraction (docID→context)
+
+	// sensitivityClassifier is the optional sensitivity gate.
+	// When non-nil, every transcript is classified before processing.
+	sensitivityClassifier ollama.SensitivityClassifier
 }
 
 // New creates a new Organizer with all services initialized.
@@ -90,6 +101,36 @@ func New(cfg *config.Config, driveSvc DriveService, calSvc CalendarService) *Org
 		notesDocIDs:         make(map[string]bool),
 		decisionDocContexts: make(map[string]models.DecisionDocContext),
 	}
+}
+
+// SetSensitivityClassifier sets the optional sensitivity classifier for the
+// organizer pipeline. When set, every transcript is classified before processing.
+func (o *Organizer) SetSensitivityClassifier(classifier ollama.SensitivityClassifier) {
+	o.sensitivityClassifier = classifier
+}
+
+// ClassifyTranscript extracts the transcript from a document and runs the
+// sensitivity classifier. Returns the result or an error. Returns nil result
+// if no classifier is set or the transcript is empty.
+func (o *Organizer) ClassifyTranscript(ctx context.Context, docCtx models.DecisionDocContext, docsSvc DocsService) (*models.SensitivityResult, error) {
+	if o.sensitivityClassifier == nil {
+		return nil, nil
+	}
+
+	transcript, err := docsSvc.ExtractTranscriptContent(ctx, docCtx.DocID)
+	if err != nil {
+		return nil, fmt.Errorf("extract transcript for sensitivity check: %w", err)
+	}
+	if transcript == nil || transcript.FullText == "" {
+		return nil, nil
+	}
+
+	result, err := o.sensitivityClassifier.Classify(ctx, transcript.FullText)
+	if err != nil {
+		return nil, fmt.Errorf("sensitivity classification: %w", err)
+	}
+
+	return result, nil
 }
 
 // GetNotesDocIDs returns the list of Google Doc IDs with "Notes" attachments.
@@ -145,6 +186,16 @@ func (o *Organizer) PrintSummary() {
 func (o *Organizer) AddTaskStats(assigned, failed int) {
 	o.stats.TasksAssigned += assigned
 	o.stats.TasksFailed += failed
+}
+
+// AddSensitivitySkipped increments the sensitivity skipped counter.
+func (o *Organizer) AddSensitivitySkipped() {
+	o.stats.SensitivitySkipped++
+}
+
+// AddSensitivityProcessed increments the sensitivity processed counter.
+func (o *Organizer) AddSensitivityProcessed() {
+	o.stats.SensitivityProcessed++
 }
 
 // AddDecisionStats updates the decision extraction statistics.
@@ -262,6 +313,12 @@ func (o *Organizer) printSummary() {
 			"events_processed", o.stats.EventsProcessed,
 			"tasks_assigned", o.stats.TasksAssigned,
 		)
+		if o.stats.SensitivitySkipped > 0 || o.stats.SensitivityProcessed > 0 {
+			o.logger.Info("Sensitivity gate",
+				"processed", o.stats.SensitivityProcessed,
+				"skipped", o.stats.SensitivitySkipped,
+			)
+		}
 		if o.stats.DecisionsProcessed > 0 {
 			o.logger.Info("Would extract decisions", "documents", o.stats.DecisionsProcessed)
 		}
@@ -281,6 +338,12 @@ func (o *Organizer) printSummary() {
 			"events_with_attachments", o.stats.EventsWithAttach,
 			"tasks_assigned", o.stats.TasksAssigned,
 		)
+		if o.stats.SensitivitySkipped > 0 || o.stats.SensitivityProcessed > 0 {
+			o.logger.Info("Sensitivity gate",
+				"processed", o.stats.SensitivityProcessed,
+				"skipped", o.stats.SensitivitySkipped,
+			)
+		}
 		if o.stats.DecisionsProcessed > 0 || o.stats.DecisionsSkipped > 0 || o.stats.DecisionsFailed > 0 {
 			o.logger.Info("Decision extraction",
 				"processed", o.stats.DecisionsProcessed,

--- a/pkg/models/models.go
+++ b/pkg/models/models.go
@@ -143,6 +143,48 @@ type DecisionDocContext struct {
 	Attendees []string
 }
 
+// SensitivityResult is the output of the sensitivity classifier for a single
+// transcript. Contains a binary determination, a category, a confidence score,
+// and a reasoning explanation. The four outputs satisfy FR-002. Reasoning is
+// logged at DEBUG level only (FR-004) to avoid leaking sensitive content into
+// standard log output.
+type SensitivityResult struct {
+	// Sensitive is true when the transcript contains sensitive content
+	// that should not be processed by cloud AI or written to files.
+	Sensitive bool `json:"sensitive"`
+
+	// Category classifies the type of sensitive content detected.
+	// One of: hr, legal, financial, health, termination, none.
+	Category string `json:"category"`
+
+	// Score is the classifier's confidence in the determination (0.0–1.0).
+	// Transcripts with Score >= the configured threshold are treated as sensitive.
+	Score float64 `json:"score"`
+
+	// Reasoning explains why the content was classified as sensitive or not.
+	// Logged at DEBUG level only (FR-004) to avoid leaking sensitive content
+	// into standard log output.
+	Reasoning string `json:"reasoning"`
+}
+
+// CheckboxItem represents a single checkbox action item from a Google Doc.
+// Moved from internal/gemini/client.go to pkg/models so both internal/ollama
+// and internal/gemini can use it without cross-package dependency (review A-1).
+type CheckboxItem struct {
+	Index int    `json:"index"`
+	Text  string `json:"text"`
+}
+
+// CheckboxAssignment is the result of assignee extraction for a checkbox item.
+// Moved from internal/gemini/client.go to pkg/models so both internal/ollama
+// and internal/gemini can use it without cross-package dependency (review A-1).
+type CheckboxAssignment struct {
+	Index    int    `json:"index"`
+	Text     string `json:"text"`
+	Assignee string `json:"assignee"`
+	Email    string `json:"email"` // Populated after name-to-email resolution
+}
+
 // Attendee represents a calendar event attendee.
 type Attendee struct {
 	// Email is the attendee's email address

--- a/specs/014-local-ai-ollama/checklists/requirements.md
+++ b/specs/014-local-ai-ollama/checklists/requirements.md
@@ -1,0 +1,37 @@
+# Specification Quality Checklist: Local AI via Ollama with IBM Granite
+
+**Purpose**: Validate specification completeness and quality before proceeding to planning
+**Created**: 2026-04-20
+**Feature**: [spec.md](../spec.md)
+
+## Content Quality
+
+- [x] No implementation details (languages, frameworks, APIs)
+- [x] Focused on user value and business needs
+- [x] Written for non-technical stakeholders
+- [x] All mandatory sections completed
+
+## Requirement Completeness
+
+- [x] No [NEEDS CLARIFICATION] markers remain
+- [x] Requirements are testable and unambiguous
+- [x] Success criteria are measurable
+- [x] Success criteria are technology-agnostic (no implementation details)
+- [x] All acceptance scenarios are defined
+- [x] Edge cases are identified
+- [x] Scope is clearly bounded
+- [x] Dependencies and assumptions identified
+
+## Feature Readiness
+
+- [x] All functional requirements have clear acceptance criteria
+- [x] User scenarios cover primary flows
+- [x] Feature meets measurable outcomes defined in Success Criteria
+- [x] No implementation details leak into specification
+
+## Notes
+
+- All items passed on first validation iteration.
+- Spec was developed through extensive exploration (explore mode) with the user, covering architecture options, model selection, fallback behavior, and sensitivity classification categories.
+- Key design decisions resolved during exploration: hard-stop when Ollama unavailable (not graceful degradation), category+score logging only (reasoning at debug level), dry-run proceeds with classification logged, Granite Guardian for sensitivity, Granite 3.2:8b for assignments.
+- The spec deliberately uses "local AI service" and "cloud AI service" in FRs to remain technology-agnostic, while the overview names Ollama and Granite for reader context.

--- a/specs/014-local-ai-ollama/data-model.md
+++ b/specs/014-local-ai-ollama/data-model.md
@@ -1,0 +1,406 @@
+# Data Model: Local AI via Ollama with IBM Granite
+
+**Feature**: 014-local-ai-ollama
+**Date**: 2026-04-20
+**Purpose**: Define types, interfaces, and configuration schema
+
+---
+
+## 1. New Types
+
+### SensitivityResult (pkg/models/models.go)
+
+```go
+// SensitivityResult is the output of the sensitivity classifier for a single
+// transcript. Contains a binary determination, a category, a confidence score,
+// and a reasoning explanation.
+type SensitivityResult struct {
+    // Sensitive is true when the transcript contains sensitive content
+    // that should not be processed by cloud AI or written to files.
+    Sensitive bool `json:"sensitive"`
+
+    // Category classifies the type of sensitive content detected.
+    // One of: hr, legal, financial, health, termination, none.
+    Category string `json:"category"`
+
+    // Score is the classifier's confidence in the determination (0.0–1.0).
+    // Transcripts with Score >= the configured threshold are treated as sensitive.
+    Score float64 `json:"score"`
+
+    // Reasoning explains why the content was classified as sensitive or not.
+    // Logged at DEBUG level only (FR-004) to avoid leaking sensitive content
+    // into standard log output.
+    Reasoning string `json:"reasoning"`
+}
+```
+
+### OllamaConfig (internal/config/config.go)
+
+```go
+// OllamaConfig holds configuration for the local AI integration via Ollama.
+type OllamaConfig struct {
+    // Enabled controls whether local AI features are active.
+    // When false, all Ollama checks and features are skipped.
+    Enabled bool `mapstructure:"enabled"`
+
+    // Endpoint is the Ollama API base URL (e.g., "http://localhost:11434").
+    Endpoint string `mapstructure:"endpoint"`
+
+    // Timeout is the HTTP request timeout for generation requests, in seconds.
+    Timeout int `mapstructure:"timeout"`
+
+    // Sensitivity holds settings for the sensitivity classification gate.
+    Sensitivity SensitivityConfig `mapstructure:"sensitivity"`
+
+    // Assignments holds settings for local task assignment.
+    Assignments AssignmentsConfig `mapstructure:"assignments"`
+
+    // LocalOnly prevents all cloud AI API calls when true.
+    // Decision extraction uses the local model instead of Gemini.
+    LocalOnly bool `mapstructure:"local_only"`
+}
+
+// SensitivityConfig holds settings for the sensitivity classification gate.
+type SensitivityConfig struct {
+    // Enabled controls whether the sensitivity gate is active (FR-006).
+    // Independent of the top-level OllamaConfig.Enabled toggle.
+    // When false, transcripts are not screened for sensitivity.
+    Enabled bool `mapstructure:"enabled"`
+
+    // Model is the Ollama model name for sensitivity classification.
+    Model string `mapstructure:"model"`
+
+    // Threshold is the minimum score for a transcript to be classified
+    // as sensitive. Comparison is >= (inclusive). Range: 0.0–1.0.
+    Threshold float64 `mapstructure:"threshold"`
+}
+
+// AssignmentsConfig holds settings for local task assignment.
+type AssignmentsConfig struct {
+    // Model is the Ollama model name for assignee extraction.
+    Model string `mapstructure:"model"`
+}
+```
+
+**Default values** (FR-021):
+```go
+Ollama: OllamaConfig{
+    Enabled:  true,
+    Endpoint: "http://localhost:11434",
+    Timeout:  120,
+    Sensitivity: SensitivityConfig{
+        Enabled:   true,
+        Model:     "granite-guardian",
+        Threshold: 0.7,
+    },
+    Assignments: AssignmentsConfig{
+        Model: "granite3.2:8b",
+    },
+    LocalOnly: false,
+}
+```
+
+---
+
+## 2. Interfaces
+
+### SensitivityClassifier (internal/ollama/guardian.go)
+
+```go
+// SensitivityClassifier classifies transcript content for sensitivity
+// before any processing occurs. Implementations must be safe for
+// concurrent use.
+type SensitivityClassifier interface {
+    // Classify analyzes a transcript and returns a sensitivity determination.
+    // Returns an error if the classification fails (model unavailable,
+    // malformed response after retry, timeout).
+    Classify(ctx context.Context, transcript string) (*models.SensitivityResult, error)
+}
+```
+
+### TaskAssigner (internal/ollama/assigner.go)
+
+```go
+// TaskAssigner extracts assignees from checkbox action items using
+// a local AI model. Produces results in the same format as the
+// existing cloud-based extraction (FR-014).
+//
+// Note: CheckboxItem and CheckboxAssignment types are defined in
+// pkg/models/models.go (moved from internal/gemini/client.go) so
+// that both internal/ollama and internal/gemini can use them without
+// creating a cross-package dependency (review finding A-1).
+type TaskAssigner interface {
+    // ExtractAssignees identifies the responsible individual for each
+    // checkbox item. Returns assignments only for items with a clear
+    // single assignee; items with group/ambiguous assignees are omitted.
+    ExtractAssignees(ctx context.Context, items []models.CheckboxItem) ([]models.CheckboxAssignment, error)
+}
+```
+
+### DecisionExtractor (internal/ollama/decisions.go)
+
+```go
+// DecisionExtractor extracts structured decisions from meeting transcripts
+// using a local AI model. Used in local-only mode as a replacement for
+// the cloud-based Gemini extraction.
+type DecisionExtractor interface {
+    // ExtractDecisions analyzes a transcript and returns categorized decisions
+    // (made, deferred, open) with text, timestamp, and context fields.
+    ExtractDecisions(ctx context.Context, transcriptText string) ([]models.Decision, error)
+}
+```
+
+### OllamaClient (internal/ollama/client.go)
+
+```go
+// Client provides low-level HTTP communication with the Ollama API.
+// All higher-level components (SensitivityClassifier, TaskAssigner,
+// DecisionExtractor) use Client for HTTP operations.
+//
+// Design decision: Single client shared across components rather than
+// each component managing its own HTTP client. This centralizes timeout
+// configuration, health checking, and model availability caching.
+type Client struct {
+    baseURL string
+    client  *http.Client
+
+    // Model availability cache (same pattern as Dewey's OllamaSynthesizer)
+    mu            sync.RWMutex
+    modelCache    map[string]bool // model name → available
+    lastCheck     time.Time
+    checkInterval time.Duration
+}
+
+// NewClient creates an OllamaClient that connects to the Ollama API
+// at the given endpoint with the specified timeout.
+func NewClient(endpoint string, timeoutSeconds int) *Client
+
+// Generate sends a prompt to the specified model via POST /api/generate
+// and returns the generated text. Uses stream=false for single-response mode.
+func (c *Client) Generate(ctx context.Context, model, prompt string) (string, error)
+
+// HealthCheck reports whether Ollama is reachable by sending GET /api/tags
+// with a 2-second timeout. Returns true if the response is HTTP 200.
+func (c *Client) HealthCheck() bool
+
+// ModelAvailable reports whether the specified model is available in the
+// Ollama instance by querying GET /api/tags. Caches results for 30 seconds.
+func (c *Client) ModelAvailable(model string) bool
+
+// ListModels returns the names of all models available in the Ollama instance.
+func (c *Client) ListModels() ([]string, error)
+```
+
+---
+
+### Moved Types: CheckboxItem and CheckboxAssignment (pkg/models/models.go)
+
+Move from `internal/gemini/client.go` to `pkg/models/models.go` to allow both
+`internal/ollama` and `internal/gemini` to use them without cross-package dependency.
+
+```go
+// CheckboxItem represents a single checkbox action item from a Google Doc.
+type CheckboxItem struct {
+    Index int
+    Text  string
+}
+
+// CheckboxAssignment is the result of assignee extraction for a checkbox item.
+type CheckboxAssignment struct {
+    Index    int
+    Text     string
+    Assignee string
+    Email    string
+}
+```
+
+Update `internal/gemini/client.go` to import these from `pkg/models` instead of defining them locally. Type aliases may be used for backward compatibility if needed.
+
+---
+
+## 3. Modified Types
+
+### Config (internal/config/config.go)
+
+Add `Ollama` field to existing `Config` struct:
+
+```go
+type Config struct {
+    // ... existing fields ...
+
+    // Ollama holds configuration for the local AI integration.
+    Ollama OllamaConfig `mapstructure:"ollama"`
+}
+```
+
+### Stats (internal/organizer/organizer.go)
+
+Add sensitivity tracking fields:
+
+```go
+type Stats struct {
+    // ... existing fields ...
+
+    // SensitivitySkipped counts transcripts skipped due to sensitivity classification.
+    SensitivitySkipped int
+
+    // SensitivityProcessed counts transcripts that passed the sensitivity gate.
+    SensitivityProcessed int
+}
+```
+
+### Organizer (internal/organizer/organizer.go)
+
+Add optional sensitivity classifier field:
+
+```go
+type Organizer struct {
+    // ... existing fields ...
+
+    // sensitivityClassifier is the optional sensitivity gate.
+    // When non-nil, every transcript is classified before processing.
+    sensitivityClassifier ollama.SensitivityClassifier
+}
+```
+
+---
+
+## 4. Ollama API Request/Response Schemas
+
+### POST /api/generate
+
+**Request**:
+```json
+{
+    "model": "granite-guardian",
+    "prompt": "You are a workplace content sensitivity classifier...",
+    "stream": false
+}
+```
+
+**Response** (stream=false):
+```json
+{
+    "model": "granite-guardian",
+    "created_at": "2026-04-20T12:00:00Z",
+    "response": "{\"sensitive\":true,\"category\":\"hr\",\"score\":0.92,\"reasoning\":\"...\"}",
+    "done": true,
+    "total_duration": 1234567890,
+    "load_duration": 123456789,
+    "prompt_eval_count": 100,
+    "eval_count": 50
+}
+```
+
+### GET /api/tags
+
+**Response**:
+```json
+{
+    "models": [
+        {
+            "name": "granite-guardian:latest",
+            "model": "granite-guardian:latest",
+            "modified_at": "2026-04-20T12:00:00Z",
+            "size": 4700000000
+        },
+        {
+            "name": "granite3.2:8b",
+            "model": "granite3.2:8b",
+            "modified_at": "2026-04-20T12:00:00Z",
+            "size": 4900000000
+        }
+    ]
+}
+```
+
+---
+
+## 5. Configuration YAML Schema
+
+```yaml
+# Local AI configuration (Ollama with IBM Granite models)
+ollama:
+  # Enable local AI features (sensitivity gate, local task assignment)
+  # When disabled, all Ollama checks and features are skipped.
+  # Default: true
+  enabled: true
+
+  # Ollama API endpoint
+  # Default: http://localhost:11434
+  endpoint: "http://localhost:11434"
+
+  # Request timeout for generation requests (seconds)
+  # Default: 120
+  timeout: 120
+
+  # Sensitivity classification settings
+  sensitivity:
+    # Model for sensitivity classification
+    # Default: granite-guardian
+    model: "granite-guardian"
+
+    # Sensitivity threshold (0.0–1.0)
+    # Transcripts scoring >= this value are skipped.
+    # Default: 0.7
+    threshold: 0.7
+
+  # Task assignment settings
+  assignments:
+    # Model for assignee extraction
+    # Default: granite3.2:8b
+    model: "granite3.2:8b"
+
+  # Local-only mode
+  # When true, all AI processing runs locally (no cloud AI calls).
+  # Decision extraction uses the local model instead of Gemini.
+  # Default: false
+  local_only: false
+```
+
+---
+
+## 6. Error Types
+
+No custom error types are introduced. All errors use `fmt.Errorf` with `%w` wrapping per constitution principle V and convention CS-006.
+
+Sentinel-style errors for specific conditions:
+
+```go
+// ErrOllamaUnavailable indicates Ollama is configured but not reachable.
+// The pipeline must hard-stop (FR-009).
+var ErrOllamaUnavailable = errors.New("ollama is configured but not available")
+
+// ErrModelNotAvailable indicates a required model is not pulled.
+var ErrModelNotAvailable = errors.New("required ollama model is not available")
+
+// ErrMalformedResponse indicates the model returned unparseable output
+// after the retry attempt.
+var ErrMalformedResponse = errors.New("ollama model returned malformed response")
+```
+
+---
+
+## 7. Package Dependency Graph
+
+```
+cmd/gcal-organizer/
+    └── imports: internal/config, internal/ollama, internal/organizer
+
+internal/organizer/
+    └── imports: internal/config, internal/ollama (interfaces only), pkg/models
+
+internal/ollama/
+    ├── client.go    → imports: net/http, encoding/json (stdlib only)
+    ├── guardian.go   → imports: internal/ollama (Client), pkg/models
+    ├── assigner.go   → imports: internal/ollama (Client), internal/gemini (types only)
+    └── decisions.go  → imports: internal/ollama (Client), pkg/models
+
+internal/config/
+    └── imports: (no new imports — OllamaConfig is a plain struct)
+
+pkg/models/
+    └── imports: (no new imports — SensitivityResult is a plain struct)
+```
+
+**No circular dependencies.** The `internal/ollama` package is a leaf that imports only stdlib, `pkg/models`, and `internal/gemini` (for shared types like `CheckboxItem` and `CheckboxAssignment`). The organizer imports ollama interfaces, not concrete types.

--- a/specs/014-local-ai-ollama/plan.md
+++ b/specs/014-local-ai-ollama/plan.md
@@ -1,0 +1,97 @@
+# Implementation Plan: Local AI via Ollama with IBM Granite
+
+**Branch**: `014-local-ai-ollama` | **Date**: 2026-04-20 | **Spec**: [spec.md](spec.md)
+**Input**: Feature specification from `/specs/014-local-ai-ollama/spec.md`
+
+## Summary
+
+Add a local AI layer using Ollama with IBM Granite models to gcal-organizer. The feature introduces three capabilities: (1) a sensitivity gate that classifies every meeting transcript before processing and skips sensitive content, (2) local task assignment that replaces Gemini for assignee extraction, and (3) an optional local-only mode that eliminates all cloud AI dependencies. The implementation uses raw HTTP to Ollama's REST API (following the proven Dewey pattern), with hard-stop behavior when Ollama is configured but unavailable. Doctor and init commands are extended to validate Ollama setup.
+
+## Technical Context
+
+**Language/Version**: Go 1.24.0 (toolchain go1.24.12)
+**Primary Dependencies**: `net/http` (Ollama REST API — no SDK), `github.com/spf13/cobra` (CLI), `github.com/spf13/viper` (config), `github.com/charmbracelet/log` (logging), `github.com/charmbracelet/huh` (interactive prompts)
+**Storage**: N/A (no new data persistence; configuration via existing YAML config file)
+**Testing**: `go test -race -count=1 ./...` with `net/http/httptest` for Ollama API mocking
+**Target Platform**: macOS (primary), Linux (secondary)
+**Project Type**: Single Go CLI application
+**Performance Goals**: Sensitivity classification completes within Ollama's configured timeout (default 120s); doctor checks complete in <3 seconds (SC-005)
+**Constraints**: No new Go dependencies (raw HTTP only — FR-012); hard-stop on Ollama unavailability (FR-009); all tests must pass under race detector (TC-005)
+**Scale/Scope**: 4 new source files in `internal/ollama/`, modifications to config, organizer, and selfservice
+
+## Constitution Check
+
+*GATE: Must pass before Phase 0 research. Re-check after Phase 1 design.*
+
+| Principle | Status | Notes |
+|-----------|--------|-------|
+| I. CLI-First Architecture | ✅ PASS | All Ollama features exposed via existing CLI commands (`run`, `doctor`, `init`). New config via YAML. No new commands needed. |
+| II. API-Key Authentication Mode | ✅ PASS | Ollama uses no authentication (local HTTP). Gemini API key handling unchanged. No new credentials to manage. |
+| III. Test-Driven Development | ✅ PASS | All Ollama HTTP interactions testable via `httptest.NewServer`. No external dependencies needed for testing. Follows Dewey's proven test pattern. |
+| IV. Idiomatic Go | ✅ PASS | Standard `net/http` client, `context.Context` for timeouts, `fmt.Errorf` with `%w` for error wrapping. No new external dependencies (FR-012). |
+| V. Graceful Error Handling | ✅ PASS | Hard-stop with actionable error messages when Ollama unavailable (FR-008/FR-009). Error messages include specific fix steps (install, start, pull commands). |
+| VI. Observability | ✅ PASS | Sensitivity classification logged at INFO (category + score + doc URL), reasoning at DEBUG only (FR-004). Dry-run mode supported (FR-007). |
+| VII. Self-Serve Diagnostics | ✅ PASS | Doctor command extended with 4 new checks (FR-023–FR-027). Init command extended with model pull prompt (FR-028). |
+
+**Quality Gates**:
+| Gate | Status | Notes |
+|------|--------|-------|
+| `go build ./...` | Will verify | New package must compile |
+| `go test ./...` | Will verify | All new tests must pass |
+| `go vet ./...` | Will verify | No warnings |
+| `gofmt` | Will verify | All new files formatted |
+| `go mod tidy` | Will verify | No new dependencies expected |
+| `make ci` | Will verify | Must mirror CI exactly |
+
+**No constitution violations. No complexity tracking needed.**
+
+## Project Structure
+
+### Documentation (this feature)
+
+```text
+specs/014-local-ai-ollama/
+├── plan.md              # This file
+├── research.md          # Phase 0: Ollama API patterns, Granite models, prompt engineering
+├── data-model.md        # Phase 1: Types, interfaces, config schema
+├── quickstart.md        # Phase 1: Integration guide
+├── checklists/
+│   └── requirements.md  # Pre-existing spec quality checklist
+└── tasks.md             # Phase 2 output (/speckit.tasks — NOT created by /speckit.plan)
+```
+
+### Source Code (repository root)
+
+```text
+internal/
+├── ollama/
+│   ├── client.go         # OllamaClient: HTTP client, health check, model availability
+│   ├── guardian.go        # SensitivityClassifier: granite-guardian via /api/generate
+│   ├── assigner.go        # TaskAssigner: granite3.2:8b for assignee extraction
+│   ├── decisions.go       # DecisionExtractor: granite3.2:8b for local-only decisions
+│   ├── client_test.go     # Client tests with httptest
+│   ├── guardian_test.go   # Sensitivity classifier tests
+│   ├── assigner_test.go   # Task assigner tests
+│   └── decisions_test.go  # Decision extractor tests
+├── config/
+│   └── config.go          # MODIFIED: Add OllamaConfig nested struct
+└── organizer/
+    └── organizer.go       # MODIFIED: Add sensitivity gate to pipeline, swap AI services
+
+cmd/gcal-organizer/
+├── selfservice.go         # MODIFIED: Add 4 doctor checks, init model pull prompt
+└── main.go                # MODIFIED: Wire OllamaClient into pipeline
+
+pkg/models/
+└── models.go              # MODIFIED: Add SensitivityResult struct
+```
+
+**Structure Decision**: Follows existing project layout. New `internal/ollama/` package is a leaf dependency (imports only stdlib + `pkg/models` + `internal/config`). Mirrors the Dewey `llm/` package pattern: separate files for client, classifier, and assigner per Single Responsibility Principle.
+
+## Complexity Tracking
+
+> No constitution violations. Table intentionally empty.
+
+| Violation | Why Needed | Simpler Alternative Rejected Because |
+|-----------|------------|-------------------------------------|
+| — | — | — |

--- a/specs/014-local-ai-ollama/quickstart.md
+++ b/specs/014-local-ai-ollama/quickstart.md
@@ -1,0 +1,328 @@
+# Quickstart: Local AI via Ollama with IBM Granite
+
+**Feature**: 014-local-ai-ollama
+**Date**: 2026-04-20
+**Purpose**: Integration guide for implementers
+
+---
+
+## 1. Prerequisites
+
+Before implementing, ensure you understand:
+
+1. **Dewey's Ollama pattern** — Read `llm/llm.go` and `llm/llm_test.go` in the Dewey repo (`unbound-force/dewey`). This is the reference implementation for raw HTTP to Ollama's REST API. Our `internal/ollama/client.go` follows this pattern exactly.
+
+2. **Existing Gemini integration** — Read `internal/gemini/client.go`. The prompts for assignee extraction (`ExtractAssigneesFromCheckboxes`) and decision extraction (`ExtractDecisions`) will be reused with minimal modification for the local models.
+
+3. **Pipeline orchestration** — Read `internal/organizer/organizer.go`, specifically `ExtractDecisionsForDoc()` and `RunFullWorkflow()`. The sensitivity gate inserts before decision extraction. The AI service swap (Gemini → Ollama) happens at the caller level.
+
+4. **Doctor/init pattern** — Read `cmd/gcal-organizer/selfservice.go`. The 10 existing doctor checks and the init command's interactive flow are the templates for the 4 new Ollama checks and the model pull prompt.
+
+5. **Config pattern** — Read `internal/config/config.go`. The `DecisionsConfig` nested struct is the template for `OllamaConfig`.
+
+---
+
+## 2. Implementation Order
+
+### Phase 1: Foundation (no pipeline changes)
+
+1. **`pkg/models/models.go`** — Add `SensitivityResult` struct
+2. **`internal/config/config.go`** — Add `OllamaConfig` struct and defaults
+3. **`internal/ollama/client.go`** — HTTP client (Generate, HealthCheck, ModelAvailable, ListModels)
+4. **`internal/ollama/client_test.go`** — Full test suite with httptest
+
+### Phase 2: Sensitivity Gate
+
+5. **`internal/ollama/guardian.go`** — SensitivityClassifier implementation
+6. **`internal/ollama/guardian_test.go`** — Classification tests (sensitive, not sensitive, malformed response, threshold boundary)
+7. **`internal/organizer/organizer.go`** — Wire sensitivity gate into pipeline
+
+### Phase 3: Local Task Assignment
+
+8. **`internal/ollama/assigner.go`** — TaskAssigner implementation (reuse Gemini prompt)
+9. **`internal/ollama/assigner_test.go`** — Assignment tests (single assignee, group, ambiguous)
+10. Wire into caller (replace Gemini for task assignment when Ollama enabled)
+
+### Phase 4: Local-Only Mode
+
+11. **`internal/ollama/decisions.go`** — DecisionExtractor implementation (reuse Gemini prompt)
+12. **`internal/ollama/decisions_test.go`** — Decision extraction tests
+13. Wire local-only mode: swap Gemini for Ollama when `local_only=true`
+
+### Phase 5: Doctor/Init + Documentation
+
+14. **`cmd/gcal-organizer/selfservice.go`** — Add 4 doctor checks + init model pull
+15. **Documentation** — Update README.md, SETUP.md, config.yaml template
+
+---
+
+## 3. Key Integration Points
+
+### 3.1 OllamaClient (client.go)
+
+Follow Dewey's `OllamaSynthesizer` pattern exactly:
+
+```go
+// NewClient creates an Ollama HTTP client.
+func NewClient(endpoint string, timeoutSeconds int) *Client {
+    return &Client{
+        baseURL: endpoint,
+        client: &http.Client{
+            Timeout: time.Duration(timeoutSeconds) * time.Second,
+        },
+        modelCache:    make(map[string]bool),
+        checkInterval: 30 * time.Second,
+    }
+}
+
+// Generate sends POST /api/generate with stream=false.
+func (c *Client) Generate(ctx context.Context, model, prompt string) (string, error) {
+    reqBody := generateRequest{Model: model, Prompt: prompt, Stream: false}
+    body, err := json.Marshal(reqBody)
+    // ... http.NewRequestWithContext, c.client.Do, io.LimitReader ...
+}
+```
+
+### 3.2 Sensitivity Gate Integration
+
+The sensitivity gate inserts at the beginning of `ExtractDecisionsForDoc()`:
+
+```go
+func (o *Organizer) ExtractDecisionsForDoc(ctx context.Context, docCtx models.DecisionDocContext, ...) error {
+    // NEW: Sensitivity gate (before any other processing)
+    if o.sensitivityClassifier != nil {
+        result, err := o.sensitivityClassifier.Classify(ctx, transcript.FullText)
+        if err != nil {
+            return fmt.Errorf("sensitivity classification failed: %w", err)
+        }
+
+        // Log classification result (FR-004)
+        o.logger.Info("Sensitivity classification",
+            "category", result.Category,
+            "score", result.Score,
+            "doc", docURL,
+        )
+        if o.config.Verbose {
+            o.logger.Debug("Sensitivity reasoning", "reasoning", result.Reasoning)
+        }
+
+        if result.Score >= o.config.Ollama.Sensitivity.Threshold {
+            if !o.config.DryRun {
+                o.logger.Info("Skipping sensitive transcript",
+                    "category", result.Category,
+                    "score", result.Score,
+                    "doc", docURL,
+                )
+                o.stats.SensitivitySkipped++
+                return nil
+            }
+            // Dry-run: log but proceed (FR-007)
+            o.logger.Warn("Would skip sensitive transcript (dry-run)",
+                "category", result.Category,
+                "score", result.Score,
+                "doc", docURL,
+            )
+        }
+        o.stats.SensitivityProcessed++
+    }
+
+    // ... existing decision extraction logic ...
+}
+```
+
+### 3.3 Config Loading
+
+Add to `DefaultConfig()`:
+
+```go
+func DefaultConfig() *Config {
+    // ... existing defaults ...
+    return &Config{
+        // ... existing fields ...
+        Ollama: OllamaConfig{
+            Enabled:  true,
+            Endpoint: "http://localhost:11434",
+            Timeout:  120,
+            Sensitivity: SensitivityConfig{
+                Model:     "granite-guardian",
+                Threshold: 0.7,
+            },
+            Assignments: AssignmentsConfig{
+                Model: "granite3.2:8b",
+            },
+            LocalOnly: false,
+        },
+    }
+}
+```
+
+Add viper bindings in `Load()`:
+
+```go
+mustBindEnv("ollama.enabled", "GCAL_OLLAMA_ENABLED")
+mustBindEnv("ollama.endpoint", "GCAL_OLLAMA_ENDPOINT")
+mustBindEnv("ollama.timeout", "GCAL_OLLAMA_TIMEOUT")
+mustBindEnv("ollama.sensitivity.model", "GCAL_OLLAMA_SENSITIVITY_MODEL")
+mustBindEnv("ollama.sensitivity.threshold", "GCAL_OLLAMA_SENSITIVITY_THRESHOLD")
+mustBindEnv("ollama.assignments.model", "GCAL_OLLAMA_ASSIGNMENTS_MODEL")
+mustBindEnv("ollama.local_only", "GCAL_OLLAMA_LOCAL_ONLY")
+```
+
+### 3.4 Doctor Checks
+
+Add after check #10 (Chrome debugging port), conditional on `ollama.enabled`:
+
+```go
+// 11-14: Ollama checks (only when enabled)
+if cfg.Ollama.Enabled {
+    // 11. Ollama binary
+    if _, err := exec.LookPath("ollama"); err == nil {
+        fmt.Println(styledPass("Ollama binary installed"))
+        passed++
+    } else {
+        fmt.Println(styledFail("Ollama binary not found"))
+        fmt.Println(styledFix("Install: brew install ollama"))
+        failed++
+    }
+
+    // 12. Ollama service running
+    ollamaClient := ollama.NewClient(cfg.Ollama.Endpoint, 5)
+    if ollamaClient.HealthCheck() {
+        fmt.Println(styledPass("Ollama service running"))
+        passed++
+
+        // 13. Sensitivity model
+        if ollamaClient.ModelAvailable(cfg.Ollama.Sensitivity.Model) {
+            fmt.Println(styledPass(fmt.Sprintf("Model %s available", cfg.Ollama.Sensitivity.Model)))
+            passed++
+        } else {
+            fmt.Println(styledFail(fmt.Sprintf("Model %s not found", cfg.Ollama.Sensitivity.Model)))
+            fmt.Println(styledFix(fmt.Sprintf("Run: ollama pull %s", cfg.Ollama.Sensitivity.Model)))
+            failed++
+        }
+
+        // 14. Assignment model
+        if ollamaClient.ModelAvailable(cfg.Ollama.Assignments.Model) {
+            fmt.Println(styledPass(fmt.Sprintf("Model %s available", cfg.Ollama.Assignments.Model)))
+            passed++
+        } else {
+            fmt.Println(styledFail(fmt.Sprintf("Model %s not found", cfg.Ollama.Assignments.Model)))
+            fmt.Println(styledFix(fmt.Sprintf("Run: ollama pull %s", cfg.Ollama.Assignments.Model)))
+            failed++
+        }
+    } else {
+        fmt.Println(styledFail("Ollama service not running"))
+        fmt.Println(styledFix("Run: ollama serve"))
+        failed++
+        // Skip model checks when service is down
+        fmt.Println(styledWarn("Model checks skipped (Ollama not running)"))
+        warned += 2
+    }
+}
+```
+
+### 3.5 Init Model Pull
+
+Add after credentials check in `initCmd`:
+
+```go
+// Ollama model pull (when service is running)
+if cfg.Ollama.Enabled {
+    ollamaClient := ollama.NewClient(cfg.Ollama.Endpoint, 5)
+    if ollamaClient.HealthCheck() {
+        needsPull := false
+        var modelsToPull []string
+        if !ollamaClient.ModelAvailable(cfg.Ollama.Sensitivity.Model) {
+            modelsToPull = append(modelsToPull, cfg.Ollama.Sensitivity.Model)
+            needsPull = true
+        }
+        if !ollamaClient.ModelAvailable(cfg.Ollama.Assignments.Model) {
+            modelsToPull = append(modelsToPull, cfg.Ollama.Assignments.Model)
+            needsPull = true
+        }
+
+        if needsPull && !nonInteractive {
+            var pullModels bool
+            form := huh.NewForm(
+                huh.NewGroup(
+                    huh.NewConfirm().
+                        Title("Local AI models are needed for transcript screening. Pull them now?").
+                        Value(&pullModels),
+                ),
+            )
+            if err := form.Run(); err == nil && pullModels {
+                for _, model := range modelsToPull {
+                    fmt.Printf("  Pulling %s...\n", model)
+                    cmd := exec.Command("ollama", "pull", model)
+                    cmd.Stdout = os.Stdout
+                    cmd.Stderr = os.Stderr
+                    if err := cmd.Run(); err != nil {
+                        fmt.Println(styledWarn(fmt.Sprintf("Failed to pull %s: %v", model, err)))
+                    } else {
+                        fmt.Println(styledPass(fmt.Sprintf("Pulled %s", model)))
+                    }
+                }
+            }
+        }
+    }
+}
+```
+
+---
+
+## 4. Testing Strategy
+
+### 4.1 httptest Pattern (from Dewey)
+
+All Ollama HTTP interactions are tested with `httptest.NewServer`:
+
+```go
+func TestClient_Generate_Success(t *testing.T) {
+    srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+        if r.URL.Path != "/api/generate" {
+            http.NotFound(w, r)
+            return
+        }
+        var req generateRequest
+        json.NewDecoder(r.Body).Decode(&req)
+        resp := generateResponse{Response: `{"sensitive":false,"category":"none","score":0.1,"reasoning":"routine meeting"}`, Done: true}
+        json.NewEncoder(w).Encode(resp)
+    }))
+    defer srv.Close()
+
+    client := NewClient(srv.URL, 5)
+    result, err := client.Generate(context.Background(), "granite-guardian", "classify this")
+    // assert...
+}
+```
+
+### 4.2 Test Coverage Requirements
+
+| Component | Key Test Cases |
+|-----------|---------------|
+| `client.go` | Generate success, Generate error (500), Generate malformed JSON, Generate context cancellation, Generate unreachable server, HealthCheck success, HealthCheck unreachable, ModelAvailable present, ModelAvailable missing, ModelAvailable caching |
+| `guardian.go` | Classify sensitive (hr, legal, financial, health, termination), Classify not sensitive, Threshold boundary (0.70 = sensitive, 0.69 = not), Malformed response + retry, Truncation warning |
+| `assigner.go` | Single assignee extracted, Group assignee returns null, Ambiguous returns null, Multiple items batch, Empty items list |
+| `decisions.go` | Extract made/deferred/open decisions, Empty transcript, Malformed response + retry |
+| Config | OllamaConfig defaults, Viper binding, Env var override |
+| Doctor | All 4 checks pass, Binary missing, Service down, Model missing, Ollama disabled (checks skipped) |
+
+---
+
+## 5. Common Pitfalls
+
+1. **Don't import `github.com/ollama/ollama`** — FR-012 requires raw HTTP only. No SDK dependency.
+
+2. **Don't retry network errors** — Unlike Gemini (which retries transient errors), Ollama network errors indicate a real problem. Hard-stop immediately per FR-009.
+
+3. **Don't log reasoning at INFO** — FR-004 requires reasoning at DEBUG only. The reasoning may contain excerpts from the sensitive transcript.
+
+4. **Don't fall back to Gemini** — FR-009 is explicit: when Ollama is configured but unavailable, hard-stop. Never silently fall back to cloud AI.
+
+5. **Don't forget `stream: false`** — Without this, Ollama streams newline-delimited JSON objects instead of a single response. All our requests must set `stream: false`.
+
+6. **Don't skip the response body cap** — Always use `io.LimitReader(resp.Body, 50*1024*1024)` to prevent unbounded memory allocation.
+
+7. **Threshold comparison is `>=`, not `>`** — Per spec acceptance scenario 6: a score of exactly 0.70 with threshold 0.70 IS sensitive.
+
+8. **Don't modify quality gates** — Per AGENTS.md gatekeeping rules, never modify coverage thresholds, CRAP scores, or CI flags to make the implementation pass.

--- a/specs/014-local-ai-ollama/research.md
+++ b/specs/014-local-ai-ollama/research.md
@@ -1,0 +1,331 @@
+# Research: Local AI via Ollama with IBM Granite
+
+**Feature**: 014-local-ai-ollama
+**Date**: 2026-04-20
+**Purpose**: Document technical research informing implementation decisions
+
+---
+
+## 1. Ollama HTTP API Patterns (from Dewey Codebase)
+
+### Reference Implementation
+
+The Dewey project (`unbound-force/dewey`) provides a production-proven pattern for Ollama integration via raw HTTP. Key files:
+
+- **`llm/llm.go`** — `OllamaSynthesizer` struct: raw HTTP client to Ollama's REST API
+- **`llm/llm_test.go`** — Full test suite using `net/http/httptest`
+- **`embed/embed.go`** — `OllamaEmbedder`: same pattern for embeddings (different endpoint)
+- **`main.go`** — `ensureOllama()`: health check, auto-start, binary detection
+
+### API Endpoints Used
+
+| Endpoint | Method | Purpose | Request Body | Response |
+|----------|--------|---------|-------------|----------|
+| `/api/generate` | POST | Text generation | `{"model":"...", "prompt":"...", "stream":false}` | `{"response":"...", "done":true}` |
+| `/api/tags` | GET | List available models | None | `{"models":[{"name":"model:tag"},...]}` |
+
+### Key Design Patterns from Dewey
+
+1. **Raw HTTP, no SDK** (FR-012): Uses `net/http` directly. No `github.com/ollama/ollama` dependency. This keeps the dependency tree clean and avoids version coupling.
+
+2. **`stream: false`**: All requests use non-streaming mode. The response is a single JSON object with the complete generated text. This simplifies parsing and error handling.
+
+3. **Response body cap**: `io.LimitReader(resp.Body, 50*1024*1024)` prevents unbounded memory allocation from unexpectedly large responses.
+
+4. **Context propagation**: `http.NewRequestWithContext(ctx, ...)` ensures caller-imposed deadlines and cancellation are respected.
+
+5. **Model availability caching**: `Available()` caches the result of `GET /api/tags` for 30 seconds using `sync.RWMutex` with double-checked locking. Avoids redundant HTTP calls during pipeline runs.
+
+6. **Configurable HTTP timeout**: Client created with `&http.Client{Timeout: 120 * time.Second}`. Generation is slower than embedding, so the timeout is generous.
+
+7. **Test pattern**: `httptest.NewServer` with handler that validates request path, method, and body. Tests cover: success, error status, malformed response, context cancellation, unreachable server, caching behavior.
+
+8. **NoopSynthesizer**: Test double that implements the interface with configurable response/error/availability. Exported for cross-package testing.
+
+### Health Check Pattern from Dewey
+
+```go
+// From main.go — ollamaHealthCheck
+func ollamaHealthCheck(endpoint string) bool {
+    client := &http.Client{Timeout: 2 * time.Second}
+    resp, err := client.Get(endpoint + "/api/tags")
+    if err != nil { return false }
+    defer resp.Body.Close()
+    return resp.StatusCode == http.StatusOK
+}
+```
+
+### Hard Error Pattern from Dewey
+
+Dewey's `openspec/changes/archive/2026-03-29-ollama-hard-error/` documents the deliberate shift from graceful degradation to hard error when the embedding model is unavailable. The error message includes:
+- The model name
+- The endpoint
+- The fix command (`ollama pull <model>`)
+- How to skip (`--no-embeddings`)
+
+This directly informs our FR-008/FR-009 design: when Ollama is configured but unavailable, hard-stop with actionable error. No silent fallback to cloud AI.
+
+---
+
+## 2. IBM Granite Model Capabilities
+
+### Granite Guardian (Sensitivity Classification)
+
+- **Model**: `granite-guardian` (available via `ollama pull granite-guardian`)
+- **Purpose**: Safety and risk classification. Designed to identify harmful, sensitive, or risky content.
+- **Architecture**: Built on IBM Granite foundation, fine-tuned for safety classification tasks.
+- **Capabilities**: Can classify content across safety dimensions including: harmful content, sensitive personal information, workplace-inappropriate content.
+- **Prompt format**: Accepts natural language prompts describing the classification task. Returns structured assessment.
+- **Context window**: Sufficient for typical meeting transcripts (8K+ tokens). Transcripts exceeding the window should be truncated with beginning and end preserved (per spec edge case).
+
+**Sensitivity categories for our use case**:
+- `hr` — Performance reviews, disciplinary actions, complaints, accommodation requests
+- `legal` — Legal proceedings, compliance issues, regulatory matters, contracts under negotiation
+- `financial` — Compensation discussions, budget allocations involving individual salaries, M&A discussions
+- `health` — Medical information, health accommodations, wellness concerns
+- `termination` — Layoff discussions, termination decisions, severance negotiations
+- `none` — No sensitive content detected
+
+### Granite 3.2:8b (Task Assignment & Decision Extraction)
+
+- **Model**: `granite3.2:8b` (available via `ollama pull granite3.2:8b`)
+- **Purpose**: General-purpose instruction-following model with strong structured output capabilities.
+- **Parameters**: 8 billion — sufficient for structured extraction tasks (assignee identification, decision categorization).
+- **Capabilities**: JSON output generation, instruction following, text analysis, entity extraction.
+- **Context window**: 128K tokens — more than sufficient for meeting transcripts.
+- **Quality tradeoff**: For structured extraction tasks (identify assignee from "Jay will schedule the follow-up"), 8B models perform comparably to cloud models. For nuanced reasoning (decision extraction with context), quality may be lower — this is an accepted tradeoff for local-only mode (per spec assumptions).
+
+---
+
+## 3. Prompt Engineering for Sensitivity Classification
+
+### Classification Prompt Design
+
+The sensitivity classifier prompt must:
+1. Define the classification task clearly
+2. Enumerate the sensitivity categories with examples
+3. Request structured JSON output with all four fields (sensitive, category, score, reasoning)
+4. Include few-shot examples for calibration
+
+### Proposed Prompt Template
+
+```
+You are a workplace content sensitivity classifier. Analyze the following meeting transcript and determine if it contains sensitive content that should not be processed by cloud AI services or written to external files.
+
+Classify the transcript into one of these categories:
+- "hr": Performance reviews, disciplinary actions, employee complaints, accommodation requests, hiring/firing discussions about specific individuals
+- "legal": Legal proceedings, compliance investigations, regulatory matters, contracts under negotiation, litigation strategy
+- "financial": Individual compensation discussions, salary negotiations, M&A discussions, confidential budget allocations
+- "health": Medical information, health accommodations, wellness concerns about specific individuals
+- "termination": Layoff planning, termination decisions, severance negotiations, reduction-in-force discussions
+- "none": No sensitive content detected
+
+Return your analysis as a JSON object with these fields:
+- "sensitive": boolean (true if the transcript contains sensitive content)
+- "category": string (one of: hr, legal, financial, health, termination, none)
+- "score": number between 0.0 and 1.0 (confidence in the classification)
+- "reasoning": string (brief explanation of why the content is or is not sensitive)
+
+Important rules:
+1. Err on the side of caution — if uncertain, classify as sensitive with a moderate score
+2. Focus on content about SPECIFIC INDIVIDUALS, not general policy discussions
+3. A meeting about "updating the PTO policy" is NOT sensitive; a meeting about "Sarah's excessive absences" IS sensitive
+4. Return ONLY the JSON object, no other text
+
+Transcript:
+%s
+```
+
+### JSON Parsing Strategy
+
+The response parsing follows the same pattern as `gemini/client.go`:
+1. Strip markdown code fences (`\`\`\`json` / `\`\`\``)
+2. Trim whitespace
+3. Attempt JSON unmarshal into `SensitivityResult` struct
+4. Validate category is one of the known values (default to "none" if unknown)
+5. Validate score is in [0.0, 1.0] range (clamp if out of range)
+
+### Retry Strategy
+
+Per spec edge case: "The system retries once. If the retry also fails, it stops the pipeline with an error describing the malformed response."
+
+This differs from the Gemini retry strategy (which uses exponential backoff with 5 retries for transient errors). For Ollama:
+- **Malformed output**: Retry once (total 2 attempts). If both fail, hard-stop.
+- **Network/timeout errors**: Hard-stop immediately (FR-009 — no graceful degradation).
+- **Rationale**: Ollama is local, so network errors indicate a real problem (service crashed, not running). Retrying network errors wastes time.
+
+---
+
+## 4. Task Assignment Prompt Reuse
+
+The local task assignment prompt can reuse the existing Gemini prompt from `internal/gemini/client.go:ExtractAssigneesFromCheckboxes()` with minimal modification. The prompt is model-agnostic — it describes the task, provides examples, and requests JSON output.
+
+**Key compatibility requirement**: The local model must produce the same JSON schema:
+```json
+[
+  {"index": 0, "assignee": "Jay"},
+  {"index": 1, "assignee": null}
+]
+```
+
+The `parseAssignmentsResponse()` function in `gemini/client.go` can be extracted to a shared utility or duplicated in the ollama package. Given that the parsing logic is simple (JSON unmarshal + index mapping), duplication is acceptable to keep packages independent.
+
+---
+
+## 5. Decision Extraction Prompt Reuse
+
+Similarly, the decision extraction prompt from `internal/gemini/client.go:ExtractDecisions()` can be reused for local-only mode. The prompt requests the same three categories (made, deferred, open) with the same fields (text, timestamp, context).
+
+The `parseDecisionsResponse()` function follows the same pattern and can be reused or duplicated.
+
+**Quality note**: Decision extraction requires more nuanced reasoning than assignee extraction. The 8B model may produce lower-quality results (less context, fewer implicit decisions detected). This is an accepted tradeoff per spec assumptions.
+
+---
+
+## 6. Configuration Schema Design
+
+### YAML Structure
+
+```yaml
+# Local AI configuration (Ollama)
+ollama:
+  # Enable local AI features (default: true)
+  enabled: true
+
+  # Ollama API endpoint (default: http://localhost:11434)
+  endpoint: "http://localhost:11434"
+
+  # Request timeout in seconds (default: 120)
+  timeout: 120
+
+  # Sensitivity classification settings
+  sensitivity:
+    # Model for sensitivity classification (default: granite-guardian)
+    model: "granite-guardian"
+    # Sensitivity threshold — transcripts scoring >= this are skipped (default: 0.7)
+    threshold: 0.7
+
+  # Task assignment settings
+  assignments:
+    # Model for assignee extraction (default: granite3.2:8b)
+    model: "granite3.2:8b"
+
+  # Local-only mode — all AI processing runs locally, no cloud AI calls
+  local_only: false
+```
+
+### Viper Binding
+
+Following the existing pattern in `config.go`:
+```go
+mustBindEnv("ollama.enabled", "GCAL_OLLAMA_ENABLED")
+mustBindEnv("ollama.endpoint", "GCAL_OLLAMA_ENDPOINT")
+mustBindEnv("ollama.timeout", "GCAL_OLLAMA_TIMEOUT")
+mustBindEnv("ollama.sensitivity.model", "GCAL_OLLAMA_SENSITIVITY_MODEL")
+mustBindEnv("ollama.sensitivity.threshold", "GCAL_OLLAMA_SENSITIVITY_THRESHOLD")
+mustBindEnv("ollama.assignments.model", "GCAL_OLLAMA_ASSIGNMENTS_MODEL")
+mustBindEnv("ollama.local_only", "GCAL_OLLAMA_LOCAL_ONLY")
+```
+
+---
+
+## 7. Pipeline Integration Points
+
+### Current Pipeline Flow (organizer.go)
+
+```
+RunFullWorkflow:
+  1. OrganizeDocuments (Drive operations)
+  2. SyncCalendarAttachments (Calendar → Drive shortcuts)
+  [caller handles:]
+  3. Assign Tasks (browser automation)
+  4. Extract Decisions (Gemini → Docs tab + markdown export)
+```
+
+### Modified Pipeline Flow
+
+```
+RunFullWorkflow:
+  0. Validate Ollama availability (if configured) — HARD STOP on failure
+  1. OrganizeDocuments (Drive operations) — unchanged
+  2. SyncCalendarAttachments (Calendar → Drive shortcuts) — unchanged
+  [caller handles:]
+  3. For each transcript:
+     a. Sensitivity Gate (granite-guardian) — skip if sensitive
+     b. If not sensitive (or dry-run): proceed
+  4. Assign Tasks (local granite3.2:8b instead of browser/Gemini)
+  5. Extract Decisions:
+     - local_only=true: granite3.2:8b
+     - local_only=false: Gemini (existing)
+  6. Export decisions (markdown — existing)
+```
+
+### Interface Design
+
+The sensitivity gate introduces a new interface consumed by the organizer:
+
+```go
+// SensitivityClassifier classifies transcript content for sensitivity.
+type SensitivityClassifier interface {
+    Classify(ctx context.Context, transcript string) (*models.SensitivityResult, error)
+}
+```
+
+The task assigner reuses the existing `GeminiService` interface pattern but for local execution:
+
+```go
+// TaskAssigner extracts assignees from checkbox items using local AI.
+type TaskAssigner interface {
+    ExtractAssignees(ctx context.Context, items []CheckboxItem) ([]CheckboxAssignment, error)
+}
+```
+
+---
+
+## 8. Doctor Check Design
+
+### New Checks (4 total, all conditional on `ollama.enabled`)
+
+| # | Check | Pass | Fail | Fix |
+|---|-------|------|------|-----|
+| 11 | Ollama binary installed | `ollama` in PATH | Binary not found | `brew install ollama` |
+| 12 | Ollama service running | `GET /api/tags` returns 200 | Connection refused / timeout | `ollama serve` |
+| 13 | Sensitivity model pulled | `granite-guardian` in `/api/tags` response | Model not in list | `ollama pull granite-guardian` |
+| 14 | Assignment model pulled | `granite3.2:8b` in `/api/tags` response | Model not in list | `ollama pull granite3.2:8b` |
+
+When `ollama.enabled` is false, all 4 checks are skipped entirely (FR-027).
+
+### Init Model Pull Prompt
+
+```
+Local AI models are needed for transcript screening.
+Pull them now? (Y/n)
+```
+
+If confirmed, runs:
+```bash
+ollama pull granite-guardian
+ollama pull granite3.2:8b
+```
+
+---
+
+## 9. Transcript Truncation Strategy
+
+Per spec edge case: "The system truncates the transcript with a warning log and classifies/processes the truncated version. The truncation point preserves the beginning and end of the transcript."
+
+**Strategy**: Keep first 60% and last 40% of the content when truncation is needed. Sensitive topics are most likely introduced at the beginning (agenda items) or summarized at the end (action items, next steps).
+
+**Implementation**: Check byte length against model context window (configurable, default ~6000 tokens ≈ ~24000 characters for granite-guardian). If exceeded, take first 60% of characters + `\n\n[... transcript truncated ...]\n\n` + last 40% of characters.
+
+---
+
+## 10. Key Risks and Mitigations
+
+| Risk | Impact | Mitigation |
+|------|--------|------------|
+| Granite Guardian misclassifies non-sensitive content as sensitive | False positives skip legitimate transcripts | Configurable threshold (default 0.7), dry-run mode to preview classifications, verbose logging of reasoning |
+| Granite 3.2:8b produces lower quality assignments than Gemini | Incorrect or missing assignees | Same prompt as Gemini (proven), SC-002 requires 90% agreement on test set |
+| Ollama service crashes mid-pipeline | Pipeline hangs until timeout | Configurable timeout (default 120s), hard-stop with actionable error |
+| Model context window exceeded | Truncated transcripts miss sensitive content | Preserve beginning + end (where sensitive topics most likely appear), log warning |
+| User forgets to start Ollama before running pipeline | Confusing error | Doctor check + clear error message with `ollama serve` fix instruction |

--- a/specs/014-local-ai-ollama/spec.md
+++ b/specs/014-local-ai-ollama/spec.md
@@ -1,0 +1,179 @@
+# Feature Specification: Local AI via Ollama with IBM Granite
+
+**Feature Branch**: `014-local-ai-ollama`
+**Created**: 2026-04-20
+**Status**: Draft
+**Input**: Add local AI via Ollama with IBM Granite models for transcript sensitivity gating, local task assignment, and local-only mode. Based on exploration of Dewey's Ollama integration pattern and IBM Granite model capabilities.
+
+## Overview
+
+gcal-organizer currently sends all meeting transcripts to Google's Gemini cloud AI for decision extraction and task assignment. This presents two problems: (1) sensitive meeting content -- HR concerns, legal matters, compensation discussions -- is sent to a cloud service without any screening, and (2) users who prefer to keep meeting data local have no option to do so.
+
+This feature adds a local AI layer using Ollama with IBM Granite models. A sensitivity classifier (Granite Guardian) screens every transcript before any processing occurs. If a transcript is classified as sensitive, it is skipped entirely -- no cloud AI calls, no document modifications, no local exports. For task assignment, a smaller Granite model replaces Gemini, keeping that data local by default. An optional local-only mode runs everything through Granite, eliminating all cloud AI dependencies.
+
+When Ollama is configured, it is a hard requirement: if Ollama is not available (not installed, not running, or models not pulled), the pipeline stops with an actionable error rather than silently falling back to cloud processing. This is a deliberate security posture -- if the user has opted into local AI screening, bypassing it would violate their intent.
+
+## User Scenarios & Testing *(mandatory)*
+
+### User Story 1 - Sensitivity Gate (Priority: P1)
+
+As a meeting organizer who processes transcripts from meetings that sometimes involve sensitive topics (HR concerns, legal matters, compensation), I want the system to automatically detect sensitive content and skip processing those transcripts so that sensitive information is never sent to cloud AI services or written to local files.
+
+**Why this priority**: This is the core safety feature. Without it, all transcripts are processed indiscriminately, including those containing private HR discussions, legal matters, or personnel actions. This must be the first capability delivered because it gates all other processing.
+
+**Independent Test**: Can be tested by providing transcripts with known sensitive content (e.g., performance review language, termination discussion) and verifying the pipeline skips them while logging the classification result.
+
+**Acceptance Scenarios**:
+
+1. **Given** a meeting transcript that discusses an employee performance concern, **When** the sensitivity classifier runs, **Then** the transcript is classified as sensitive with category "hr" and a score above the configured threshold, and all processing (decision extraction, task assignment, document modification, local export) is skipped for that transcript.
+2. **Given** a meeting transcript about a routine sprint planning session, **When** the sensitivity classifier runs, **Then** the transcript is classified as not sensitive and processing proceeds normally.
+3. **Given** a sensitive transcript is skipped, **When** the user reviews the log output, **Then** they see the category and score of the classification along with the Google Doc URL for the skipped document (e.g., "Skipped sensitive transcript: category=hr, score=0.92, doc=https://docs.google.com/document/d/abc123/edit").
+4. **Given** the `--dry-run` flag is set, **When** a transcript is classified as sensitive, **Then** the classification result and Google Doc URL are logged, but processing proceeds anyway so the user can see the full dry-run output for all transcripts.
+5. **Given** the sensitivity threshold is configured at 0.7, **When** a transcript receives a score of 0.65, **Then** it is NOT classified as sensitive and processing proceeds normally.
+6. **Given** the sensitivity threshold is configured at 0.7, **When** a transcript receives a score of 0.70, **Then** it IS classified as sensitive (threshold is inclusive: score >= threshold).
+7. **Given** the user has set the `--verbose` flag, **When** a transcript is classified (sensitive or not), **Then** the classification reasoning is included in the log output at debug level.
+
+---
+
+### User Story 2 - Local Task Assignment (Priority: P2)
+
+As a user who processes meeting transcripts with action items, I want task assignment (identifying who is responsible for each action item) to run locally on my machine so that action item content is not sent to a cloud AI service.
+
+**Why this priority**: Task assignment is a structured extraction task (read checkbox items, identify assignees) that does not require the nuanced reasoning of cloud AI. Running it locally keeps action item data on the user's machine and eliminates the dependency on a cloud API key for this specific function.
+
+**Independent Test**: Can be tested by providing a set of checkbox items with known assignees and verifying the local model returns the correct assignments in the same format as the current cloud-based extraction.
+
+**Acceptance Scenarios**:
+
+1. **Given** a document with checkbox action items that include named assignees (e.g., "Jay will schedule the follow-up"), **When** task assignment runs, **Then** the local model correctly identifies "Jay" as the assignee, returning results in the same structured format as the current cloud-based extraction.
+2. **Given** a document with checkbox items that have ambiguous or group assignees (e.g., "The team will discuss"), **When** task assignment runs, **Then** the local model correctly returns no assignee for those items.
+3. **Given** the system is running and the local AI service is available, **When** task assignment is requested, **Then** the local model is used instead of the cloud AI service.
+
+---
+
+### User Story 3 - Local-Only Mode (Priority: P2)
+
+As a privacy-conscious user who does not want any meeting data sent to cloud AI services, I want a configuration option that runs all AI processing locally so that my meeting transcripts, action items, and decisions never leave my machine.
+
+**Why this priority**: This completes the local AI vision. Users in regulated industries or with strict data policies need assurance that no transcript data reaches external services. This builds on US1 (sensitivity gate) and US2 (local assignments) by adding local decision extraction.
+
+**Independent Test**: Can be tested by enabling local-only mode, running the full pipeline, and verifying that no cloud AI API calls are made while decisions and assignments are still extracted (with potentially lower quality for decisions).
+
+**Acceptance Scenarios**:
+
+1. **Given** local-only mode is enabled in the configuration, **When** the pipeline processes a meeting transcript, **Then** decision extraction uses the local model instead of the cloud AI service, and the same decision categories (made, deferred, open) are produced.
+2. **Given** local-only mode is enabled, **When** the pipeline processes action items, **Then** task assignment uses the local model (same as US2 behavior).
+3. **Given** local-only mode is enabled, **When** the pipeline processes any transcript, **Then** no network calls are made to any cloud AI service.
+4. **Given** local-only mode is enabled and the local AI service is not available, **When** the user runs the pipeline, **Then** the system stops with an error explaining that local-only mode requires the local AI service to be running, with actionable fix instructions.
+5. **Given** local-only mode is disabled (default), **When** the pipeline processes a transcript, **Then** decision extraction uses the cloud AI service (existing behavior) while task assignment and sensitivity gating use the local model.
+
+---
+
+### User Story 4 - Setup and Diagnostics (Priority: P3)
+
+As a user setting up gcal-organizer for the first time (or diagnosing issues), I want the setup and diagnostic tools to check whether the local AI service and required models are properly installed so that I can resolve issues before running the pipeline.
+
+**Why this priority**: Diagnostics make the other stories usable in practice. Without clear setup guidance and health checks, users would encounter cryptic errors when the local AI service is misconfigured.
+
+**Independent Test**: Can be tested by running the diagnostic command with and without the local AI service installed, running, and with models present/missing, verifying appropriate pass/warn/fail output for each state.
+
+**Acceptance Scenarios**:
+
+1. **Given** the local AI service is installed, running, and all required models are present, **When** the user runs the diagnostic command, **Then** all local AI checks pass.
+2. **Given** the local AI service binary is not installed, **When** the user runs the diagnostic command, **Then** the check fails with the message "Install the local AI service: brew install ollama".
+3. **Given** the binary is installed but the service is not running, **When** the user runs the diagnostic command, **Then** the check fails with a message to start the service.
+4. **Given** the service is running but a required model has not been pulled, **When** the user runs the diagnostic command, **Then** the check fails with a message identifying which model is missing and the command to pull it.
+5. **Given** the user runs the initial setup command, **When** the local AI service is installed and running but models are not yet pulled, **Then** the setup prompts the user interactively: "Local AI models are needed for transcript screening. Pull them now? (Y/n)" and pulls the models if confirmed.
+6. **Given** local AI is not configured (disabled in configuration), **When** the user runs the diagnostic command, **Then** the local AI checks are skipped entirely (not reported as failures).
+
+---
+
+### Edge Cases
+
+- What happens when a transcript exceeds the local model's context window? The system truncates the transcript with a warning log and classifies/processes the truncated version. The truncation point preserves the beginning and end of the transcript (where sensitive topics are most likely to be introduced or summarized).
+- What happens when the local AI service crashes mid-request? The request times out (configurable, default 120 seconds), the system treats it as a hard failure and stops the pipeline with an actionable error.
+- What happens when the sensitivity score is exactly at the threshold? The transcript is treated as sensitive (threshold comparison is >=, not >).
+- What happens when the local model returns malformed output (not valid structured data)? The system retries once. If the retry also fails, it stops the pipeline with an error describing the malformed response.
+- What happens when both local AI and cloud AI configuration exist but local-only mode is off? The sensitivity gate and task assignment use the local model. Decision extraction uses the cloud AI service. Both systems coexist.
+- What happens during `--dry-run` with a sensitive transcript? The sensitivity classification runs and is logged (with category, score, and document URL), but processing proceeds anyway so the user sees the complete dry-run output. The log clearly indicates the transcript would be skipped in a real run.
+- What happens when the local AI service is configured but the user has not yet run the setup command? The diagnostic command fails for the local AI checks. The pipeline hard-stops on first run with instructions to install and configure the local AI service.
+- What happens when the local AI service endpoint is configured to a remote address (not localhost)? The system logs a warning at startup: "Ollama endpoint is not localhost -- sensitive transcripts will be sent over the network." The sensitivity privacy guarantee only holds for local endpoints (localhost, 127.0.0.1, ::1).
+
+## Requirements *(mandatory)*
+
+### Functional Requirements
+
+**Sensitivity Gate**:
+
+- **FR-001**: The system MUST classify every meeting transcript for sensitivity before any other processing (decision extraction, task assignment, document modification, or local export) occurs.
+- **FR-002**: The sensitivity classification MUST produce four outputs: a binary determination (sensitive or not sensitive), a category (one of: hr, legal, financial, health, termination, none), a confidence score (0.0 to 1.0), and a reasoning explanation.
+- **FR-003**: When the confidence score is greater than or equal to the configured threshold, the system MUST skip all processing for that transcript.
+- **FR-004**: When a transcript is skipped due to sensitivity, the system MUST log the category, score, and Google Doc URL at the standard log level. The reasoning MUST only be logged at the verbose/debug level.
+- **FR-005**: The sensitivity threshold MUST be configurable with a default value of 0.7.
+- **FR-006**: The sensitivity gate MUST be independently enable/disable-able via configuration, separate from the local-only mode setting.
+- **FR-007**: When the `--dry-run` flag is active, the sensitivity classifier MUST run and log results (including category, score, and Google Doc URL), but processing MUST proceed regardless of the classification result.
+
+**Local AI Service Availability**:
+
+- **FR-008**: When local AI is configured (enabled in configuration), the local AI service MUST be available (installed, running, required models present) before the pipeline proceeds. If the service is unavailable, the system MUST stop with an actionable error message listing the specific fix steps.
+- **FR-009**: The system MUST NOT fall back to cloud AI when local AI is configured but unavailable. This is a hard stop, not a graceful degradation.
+- **FR-010**: The system MUST verify model availability by querying the local AI service's model listing before the first use in each run.
+- **FR-011**: The system MUST communicate with the local AI service via its HTTP interface for both text generation and model listing.
+- **FR-012**: The system MUST NOT add a direct client library dependency for the local AI service. Communication MUST use standard HTTP.
+
+**Local Task Assignment**:
+
+- **FR-013**: When local AI is configured, the system MUST use the local model for task assignment (assignee extraction from action items) instead of the cloud AI service.
+- **FR-014**: The local task assignment MUST produce results in the same structured format as the existing cloud-based extraction (assignee name per action item, or null when no clear assignee exists).
+- **FR-015**: The local model MUST apply the same assignment rules as the current cloud extraction: only return an assignee when a single named individual is clearly responsible; return null for groups, shared responsibility, non-subject mentions, and vague references.
+
+**Local-Only Mode**:
+
+- **FR-016**: The system MUST support a configuration option for local-only mode that prevents all cloud AI API calls.
+- **FR-017**: In local-only mode, decision extraction MUST use the local model instead of the cloud AI service, producing the same three decision categories (made, deferred, open) with text, timestamp, and context fields.
+- **FR-018**: In local-only mode, if the local AI service is unavailable, the system MUST stop with an error. The system MUST NOT fall back to cloud AI.
+- **FR-019**: In non-local-only mode (default), decision extraction MUST continue to use the cloud AI service while sensitivity gating and task assignment use the local model.
+
+**Configuration**:
+
+- **FR-020**: The local AI configuration MUST be a nested section in the application's configuration file with settings for: enabled toggle, service endpoint, sensitivity model name, sensitivity threshold, assignment model name, and local-only toggle.
+- **FR-021**: Each configurable value MUST have a sensible default: enabled=true, endpoint=http://localhost:11434, sensitivity model=granite-guardian, threshold=0.7, assignment model=granite3.2:8b, local-only=false.
+- **FR-022**: The generation request timeout MUST be configurable with a default of 120 seconds.
+
+**Doctor/Init**:
+
+- **FR-023**: The diagnostic command MUST check whether the local AI service binary is installed on the system.
+- **FR-024**: The diagnostic command MUST check whether the local AI service is currently running and accepting requests.
+- **FR-025**: The diagnostic command MUST check whether the sensitivity model has been pulled and is available.
+- **FR-026**: The diagnostic command MUST check whether the assignment model has been pulled and is available.
+- **FR-027**: When local AI is disabled in configuration, the diagnostic command MUST skip all local AI checks entirely.
+- **FR-028**: The setup command MUST prompt the user interactively to pull required models when the local AI service is running but models are not yet present.
+- **FR-029**: The setup documentation MUST list the local AI service as a prerequisite with installation instructions.
+
+### Key Entities
+
+- **Sensitivity Result**: The output of the sensitivity classifier for a single transcript. Contains a binary determination (sensitive/not), a category (hr, legal, financial, health, termination, none), a confidence score (0.0-1.0), and a reasoning explanation string.
+- **Local AI Configuration**: A nested configuration section controlling the local AI integration. Contains an enabled toggle, service endpoint URL, sensitivity model name, sensitivity threshold, assignment model name, local-only toggle, and request timeout.
+- **Model Availability Status**: The result of querying the local AI service for available models. Used during startup validation and diagnostic checks to confirm required models are pulled and ready.
+
+## Success Criteria *(mandatory)*
+
+### Measurable Outcomes
+
+- **SC-001**: 100% of transcripts containing sensitive content (HR, legal, financial, health, termination discussions) are detected and skipped before any cloud AI call or local file write occurs, as validated by a test suite of representative sensitive transcript samples.
+- **SC-002**: Task assignment results from the local model match the cloud model's accuracy on a test set of 20+ action items with known assignees, achieving at least 90% agreement on assignee identification.
+- **SC-003**: In local-only mode, zero network requests are made to cloud AI services during a complete pipeline run, verifiable by monitoring outbound network traffic.
+- **SC-004**: When the local AI service is configured but unavailable, the pipeline stops within 5 seconds with a clear error message that includes specific fix steps (install, start, pull commands).
+- **SC-005**: The diagnostic command accurately reports the status of all four local AI checks (binary installed, service running, sensitivity model pulled, assignment model pulled) in under 3 seconds.
+- **SC-006**: A user following the setup documentation can go from zero local AI to a fully configured system (service installed, models pulled, configuration set) in under 10 minutes.
+
+## Assumptions
+
+- The local AI service runs as a separate process on the user's machine, accessible via HTTP on localhost. The service lifecycle (start/stop) is managed by the user or their system's service manager, not by gcal-organizer.
+- The sensitivity classification model is designed for safety and risk classification tasks and can be prompted to identify workplace-sensitive content categories (HR, legal, financial, health, termination) with reasonable accuracy.
+- The task assignment model (8B parameters) has sufficient reasoning capability to extract named assignees from structured action item text, matching the quality of the current cloud-based extraction for this specific structured task.
+- The task assignment model can handle the same prompt format currently used for cloud-based extraction, producing compatible structured output.
+- Decision extraction in local-only mode will produce lower-quality results than the cloud AI service, particularly for nuanced reasoning and justification. This is an acceptable tradeoff for users who prioritize data locality over extraction quality.
+- The local AI service is available as a standard package manager installation (e.g., `brew install` on macOS) and supports pulling models from a public registry.
+- The typical meeting transcript fits within the local model's context window. Transcripts that exceed the window are truncated rather than rejected.
+- Users who configure local AI intend for it to be a hard requirement -- falling back to cloud AI when local is unavailable would violate their privacy expectations.

--- a/specs/014-local-ai-ollama/tasks.md
+++ b/specs/014-local-ai-ollama/tasks.md
@@ -1,0 +1,215 @@
+# Tasks: Local AI via Ollama with IBM Granite
+
+**Feature**: 014-local-ai-ollama
+**Generated**: 2026-04-20
+**Spec**: [spec.md](spec.md) | **Plan**: [plan.md](plan.md)
+
+---
+
+## Phase 1: Foundation — Types, Config, and HTTP Client
+
+> **Goal**: Establish the data types, configuration schema, and low-level Ollama HTTP client. No pipeline changes — all new code is leaf-level with no callers yet.
+>
+> **Checkpoint**: `go build ./...` compiles, `go test -race -count=1 ./internal/ollama/... ./internal/config/... ./pkg/models/...` passes.
+
+- [x] [T01] [US1] Add `SensitivityResult` struct to `pkg/models/models.go`
+  - Fields: `Sensitive bool`, `Category string`, `Score float64`, `Reasoning string` (all with JSON tags)
+  - GoDoc comment referencing FR-002 (four outputs) and FR-004 (reasoning at DEBUG only)
+
+- [x] [T02] [US1] Add `OllamaConfig`, `SensitivityConfig`, `AssignmentsConfig` structs to `internal/config/config.go`
+  - `OllamaConfig`: Enabled, Endpoint, Timeout, Sensitivity, Assignments, LocalOnly (all with `mapstructure` tags)
+  - `SensitivityConfig`: Model, Threshold
+  - `AssignmentsConfig`: Model
+  - Add `Ollama OllamaConfig` field to existing `Config` struct
+
+- [x] [T03] [US1] Set `OllamaConfig` defaults in `DefaultConfig()` and add viper bindings in `Load()` — `internal/config/config.go`
+  - Defaults per FR-021: enabled=true, endpoint=http://localhost:11434, timeout=120, sensitivity.model=granite-guardian, threshold=0.7, assignments.model=granite3.2:8b, local_only=false
+  - Viper bindings: `ollama.enabled` → `GCAL_OLLAMA_ENABLED`, etc. (7 bindings per research.md §6)
+  - Add viper value override logic in `Load()` matching existing pattern
+
+- [x] [T04] [US1] Create `internal/ollama/client.go` — Ollama HTTP client
+  - `Client` struct: baseURL, `*http.Client`, model cache (`sync.RWMutex` + `map[string]bool` + `time.Time` + `time.Duration`)
+  - `NewClient(endpoint string, timeoutSeconds int) *Client`
+  - `Generate(ctx context.Context, model, prompt string) (string, error)` — POST `/api/generate` with `stream:false`, `io.LimitReader` (50 MB cap), context propagation
+  - `HealthCheck() bool` — GET `/api/tags` with 2-second timeout, returns true on HTTP 200
+  - `ModelAvailable(model string) bool` — GET `/api/tags`, cache results for 30 seconds
+  - `ListModels() ([]string, error)` — GET `/api/tags`, return model names
+  - Sentinel errors: `ErrOllamaUnavailable`, `ErrModelNotAvailable`, `ErrMalformedResponse`
+  - Internal request/response types: `generateRequest`, `generateResponse`, `tagsResponse`, `modelInfo`
+  - FR-012: stdlib only (`net/http`, `encoding/json`, `io`, `sync`, `time`, `context`, `errors`, `fmt`)
+
+- [x] [T05] [US1] Create `internal/ollama/client_test.go` — Client test suite
+  - All tests use `httptest.NewServer` (no real Ollama dependency)
+  - Test cases: Generate success, Generate HTTP 500, Generate malformed JSON response, Generate context cancellation, Generate unreachable server (invalid URL), HealthCheck success, HealthCheck unreachable, ModelAvailable present (with `:latest` suffix matching), ModelAvailable missing, ModelAvailable cache hit (verify single HTTP call for repeated checks), ListModels success, ListModels error
+  - All tests run under `-race` flag
+
+---
+
+## Phase 2: Sensitivity Gate — Classifier and Pipeline Integration
+
+> **Goal**: Implement the sensitivity classifier (granite-guardian) and wire it into the organizer pipeline as a pre-processing gate. This is the core safety feature (US1 P1).
+>
+> **Checkpoint**: `go test -race -count=1 ./internal/ollama/... ./internal/organizer/...` passes. Sensitivity gate correctly skips sensitive transcripts and respects dry-run.
+
+- [x] [T06] [US1] Create `internal/ollama/guardian.go` — SensitivityClassifier implementation
+  - `SensitivityClassifier` interface: `Classify(ctx context.Context, transcript string) (*models.SensitivityResult, error)`
+  - `Guardian` struct implementing `SensitivityClassifier`, holds `*Client` + model name
+  - `NewGuardian(client *Client, model string) *Guardian`
+  - Prompt template from research.md §3 (workplace sensitivity classifier with 6 categories)
+  - JSON response parsing: strip markdown fences, unmarshal, validate category (default "none"), clamp score to [0.0, 1.0]
+  - Retry strategy: retry once on malformed response (total 2 attempts), hard-stop on network errors (FR-009)
+  - Transcript truncation: check byte length against configurable max (default ~24000 chars), keep first 60% + separator + last 40%, log warning
+
+- [x] [T07] [US1] Create `internal/ollama/guardian_test.go` — Sensitivity classifier tests
+  - Test cases: Classify sensitive (category=hr, score=0.92), Classify not sensitive (category=none, score=0.1), Threshold boundary (score=0.70 at threshold=0.70 → sensitive per FR-003), Threshold boundary (score=0.69 at threshold=0.70 → not sensitive), Malformed response + successful retry, Malformed response + failed retry → ErrMalformedResponse, Network error → immediate hard-stop (no retry), Transcript truncation (verify truncated text preserves beginning + end), All 6 categories (hr, legal, financial, health, termination, none)
+  - All tests use `httptest.NewServer`
+
+- [x] [T08] [US1] Add sensitivity gate to organizer pipeline — `internal/organizer/organizer.go`
+  - Add `sensitivityClassifier` field to `Organizer` struct (type: interface from ollama package)
+  - Add `SensitivitySkipped int` and `SensitivityProcessed int` to `Stats` struct
+  - Add `SetSensitivityClassifier(classifier)` method or constructor option
+  - Add `ClassifyTranscript(ctx, docCtx, docsSvc) (*SensitivityResult, error)` method to Organizer that extracts the transcript and runs the classifier
+  - Insert sensitivity gate in the main.go orchestration loop (Step 4 decision extraction loop), BEFORE calling `ExtractDecisionsForDoc()` — same level as the allowlist filter. This keeps ExtractDecisionsForDoc focused on extraction, not gating.
+  - Gate logic: if classifier is non-nil and sensitivity.enabled, call ClassifyTranscript; if score >= threshold, skip (continue loop) unless dry-run
+  - Logging per FR-004: category + score + doc URL at INFO; reasoning at DEBUG only
+  - Dry-run per FR-007: log classification result but proceed with processing
+  - Add integration test: inject mock classifier into organizer, verify ExtractDecisionsForDoc is NOT called when classifier returns sensitive result
+  - Update `printSummary()` to include sensitivity stats when non-zero
+
+- [x] [T09] [US1] Wire OllamaClient and sensitivity gate in `cmd/gcal-organizer/main.go`
+  - In `runCmd.RunE`: after `loadConfigAndStore()`, if `cfg.Ollama.Enabled`:
+    - Create `ollama.NewClient(cfg.Ollama.Endpoint, cfg.Ollama.Timeout)`
+    - Validate availability: `client.HealthCheck()` → hard-stop with actionable error if false (FR-008)
+    - Validate sensitivity model: `client.ModelAvailable(cfg.Ollama.Sensitivity.Model)` → hard-stop if false (FR-010)
+    - Create `ollama.NewGuardian(client, cfg.Ollama.Sensitivity.Model)`
+    - Set classifier on organizer via `SetSensitivityClassifier()`
+  - Hard-stop error messages must include fix steps: "Install: brew install ollama", "Start: ollama serve", "Pull: ollama pull <model>"
+
+---
+
+## Phase 3: Local Task Assignment
+
+> **Goal**: Replace Gemini for task assignment with local granite3.2:8b model. Same structured output format as existing cloud extraction (FR-014).
+>
+> **Checkpoint**: `go test -race -count=1 ./internal/ollama/...` passes. Assignment output format matches `gemini.CheckboxAssignment`.
+
+- [x] [T10] [US2] Create `internal/ollama/assigner.go` — TaskAssigner implementation
+  - `TaskAssigner` interface: `ExtractAssignees(ctx context.Context, items []models.CheckboxItem) ([]models.CheckboxAssignment, error)` (types moved to pkg/models per review finding A-1)
+  - `Assigner` struct implementing `TaskAssigner`, holds `*Client` + model name
+  - `NewAssigner(client *Client, model string) *Assigner`
+  - Reuse the existing Gemini prompt from `internal/gemini/client.go:ExtractAssigneesFromCheckboxes()` (model-agnostic prompt)
+  - JSON response parsing: same schema as Gemini (`[{"index":0,"assignee":"Jay"},{"index":1,"assignee":null}]`)
+  - Retry once on malformed response, hard-stop on network errors
+  - FR-015: same assignment rules — single named individual only, null for groups/shared/vague
+
+- [x] [T11] [US2] Create `internal/ollama/assigner_test.go` — Task assigner tests
+  - Test cases: Single assignee extracted ("Jay will schedule the follow-up" → assignee="Jay"), Group assignee returns null ("The team will discuss" → assignee=null), Ambiguous reference returns null ("Someone should check" → assignee=null), Multiple items batch (mixed assignees and nulls), Empty items list → nil result, Malformed response + retry, Network error → hard-stop
+  - All tests use `httptest.NewServer`
+
+- [x] [T12] [US2] Wire local task assigner in `cmd/gcal-organizer/main.go`
+  - In Step 3 (Assign Tasks): when `cfg.Ollama.Enabled`, validate assignment model availability (`client.ModelAvailable(cfg.Ollama.Assignments.Model)`)
+  - Create `ollama.NewAssigner(client, cfg.Ollama.Assignments.Model)`
+  - Pass local assigner to `runAssignTasksForDoc()` instead of Gemini client for assignee extraction (FR-013)
+  - Requires understanding how `assign_tasks.go` currently uses Gemini — may need interface extraction
+
+---
+
+## Phase 4: Local-Only Mode — Decision Extraction
+
+> **Goal**: Add local decision extraction using granite3.2:8b for users who want zero cloud AI calls. Completes the local-only mode (US3).
+>
+> **Checkpoint**: `go test -race -count=1 ./internal/ollama/...` passes. Decision output matches `[]models.Decision` format.
+
+- [x] [T13] [US3] Create `internal/ollama/decisions.go` — DecisionExtractor implementation
+  - `DecisionExtractor` interface: `ExtractDecisions(ctx context.Context, transcriptText string) ([]models.Decision, error)`
+  - `DecisionExtractor` struct (concrete type, different name to avoid collision — e.g., `LocalDecisionExtractor`), holds `*Client` + model name
+  - `NewDecisionExtractor(client *Client, model string) *LocalDecisionExtractor`
+  - Reuse the existing Gemini prompt from `internal/gemini/client.go:ExtractDecisions()` (model-agnostic prompt)
+  - JSON response parsing: same schema as Gemini (`[]models.Decision` with category, text, timestamp, context)
+  - FR-017: produce same three categories (made, deferred, open)
+  - Retry once on malformed response, hard-stop on network errors
+
+- [x] [T14] [US3] Create `internal/ollama/decisions_test.go` — Decision extractor tests
+  - Test cases: Extract made/deferred/open decisions, Empty transcript → empty result, Malformed response + successful retry, Malformed response + failed retry → error, Network error → hard-stop, Verify all three categories present in output
+  - All tests use `httptest.NewServer`
+
+- [x] [T15] [US3] Wire local-only mode in `cmd/gcal-organizer/main.go`
+  - In Step 4 (Extract Decisions): when `cfg.Ollama.Enabled && cfg.Ollama.LocalOnly`:
+    - Create `ollama.NewDecisionExtractor(client, cfg.Ollama.Assignments.Model)` (reuses assignment model for decisions)
+    - Pass local extractor to `org.ExtractDecisionsForDoc()` instead of Gemini client (FR-016, FR-017)
+  - When `cfg.Ollama.LocalOnly && !cfg.Ollama.Enabled`: error — local-only requires Ollama enabled
+  - FR-018: if local-only and Ollama unavailable → hard-stop (already handled by Phase 2 availability check)
+  - FR-019: when local-only is false (default), decision extraction continues to use Gemini
+
+- [x] [T16] [US3] Validate no cloud AI calls in local-only mode — `internal/config/config.go`
+  - Add `Validate()` enhancement: when `Ollama.LocalOnly` is true, `GeminiAPIKey` is NOT required (skip Gemini validation)
+  - FR-016: local-only mode prevents all cloud AI API calls — Gemini key becomes optional
+
+---
+
+## Phase 5: Doctor Checks and Init Integration
+
+> **Goal**: Extend the doctor command with 4 Ollama health checks and the init command with model pull prompts. Makes the other stories usable in practice (US4).
+>
+> **Checkpoint**: `go build ./...` compiles. Doctor checks display correctly for all states (installed/not, running/not, models present/missing, disabled).
+
+- [x] [T17] [US4] Add 4 Ollama doctor checks to `cmd/gcal-organizer/selfservice.go`
+  - Check 11: Ollama binary installed — `exec.LookPath("ollama")`; fail fix: "Install: brew install ollama"
+  - Check 12: Ollama service running — `ollama.NewClient(cfg.Ollama.Endpoint, 5).HealthCheck()`; fail fix: "Run: ollama serve"
+  - Check 13: Sensitivity model pulled — `client.ModelAvailable(cfg.Ollama.Sensitivity.Model)`; fail fix: "Run: ollama pull <model>"
+  - Check 14: Assignment model pulled — `client.ModelAvailable(cfg.Ollama.Assignments.Model)`; fail fix: "Run: ollama pull <model>"
+  - FR-027: when `cfg.Ollama.Enabled` is false, skip all 4 checks entirely (not reported as failures)
+  - Checks 13-14 only run if check 12 passes (service must be running to query models)
+  - When service is down, model checks show as warned ("Model checks skipped — Ollama not running")
+  - Requires loading config in doctorCmd — use `loadConfigAndStore()` or read viper directly
+
+- [x] [T18] [US4] Add model pull prompt to init command — `cmd/gcal-organizer/selfservice.go`
+  - After credentials check in `initCmd.RunE`: when `cfg.Ollama.Enabled`:
+    - Create `ollama.NewClient(cfg.Ollama.Endpoint, 5)`
+    - If service is running (`HealthCheck()`) but models are missing (`!ModelAvailable()`):
+      - Prompt: "Local AI models are needed for transcript screening. Pull them now? (Y/n)" using `huh.NewConfirm()`
+      - If confirmed: `exec.Command("ollama", "pull", model)` for each missing model, with stdout/stderr passthrough
+      - Skip prompt in `--non-interactive` mode
+  - FR-028: interactive prompt for model pull
+
+- [x] [T19] [US4] Add Ollama section to `generateConfigYAML()` — `cmd/gcal-organizer/selfservice.go`
+  - Append Ollama YAML block with all settings and comments (matching research.md §6 schema)
+  - Include: enabled, endpoint, timeout, sensitivity.model, sensitivity.threshold, assignments.model, local_only
+  - All values commented with defaults
+
+---
+
+## Phase 6: Documentation
+
+> **Goal**: Update user-facing documentation to include Ollama as a prerequisite and document the new configuration options.
+>
+> **Checkpoint**: Documentation accurately reflects the new features. No broken links.
+
+- [x] [T20] [US4] Update `docs/SETUP.md` — add Ollama as prerequisite
+  - Add Ollama installation section: `brew install ollama` (macOS), package manager (Linux)
+  - Add model pull instructions: `ollama pull granite-guardian`, `ollama pull granite3.2:8b`
+  - Add configuration section: YAML config for `ollama:` block
+  - FR-029: setup documentation lists local AI service as prerequisite
+
+- [x] [T21] [US4] Update `README.md` — document local AI features
+  - Add "Local AI" section describing sensitivity gate, local task assignment, local-only mode
+  - Add configuration reference for `ollama:` YAML block
+  - Add troubleshooting: "Ollama not running" → `ollama serve`, "Model not found" → `ollama pull <model>`
+
+---
+
+## Summary
+
+| Metric | Count |
+|--------|-------|
+| **Total tasks** | 21 |
+| **US1 (Sensitivity Gate)** | 9 (T01–T09) |
+| **US2 (Local Task Assignment)** | 3 (T10–T12) |
+| **US3 (Local-Only Mode)** | 4 (T13–T16) |
+| **US4 (Doctor/Init/Docs)** | 5 (T17–T21) |
+| **Phases** | 6 |
+| **New files** | 8 (client.go, client_test.go, guardian.go, guardian_test.go, assigner.go, assigner_test.go, decisions.go, decisions_test.go) |
+| **Modified files** | 5 (models.go, config.go, organizer.go, main.go, selfservice.go) + 2 docs (SETUP.md, README.md) |
+
+<!-- spec-review: passed -->
+<!-- code-review: passed -->


### PR DESCRIPTION
## Summary

- **Sensitivity gate**: Granite Guardian classifies every transcript before processing. Sensitive content (HR, legal, financial, health, termination) is skipped entirely -- no cloud AI calls, no document modifications, no local exports. Category + score + doc URL logged at INFO.
- **Local task assignment**: Granite 3.2:8b replaces Gemini for assignee extraction. Same structured JSON output, same assignment rules, fully local.
- **Local-only mode**: `ollama.local_only: true` runs all AI locally -- assignments AND decision extraction. Zero cloud AI calls.
- **Hard-stop security posture**: When Ollama is configured but unavailable, the pipeline stops with actionable fix instructions rather than silently falling back to cloud AI.
- **Doctor/init integration**: 4 new health checks (binary installed, service running, sensitivity model pulled, assignment model pulled). Init prompts to pull models interactively.
- **Clean package boundaries**: CheckboxItem/CheckboxAssignment moved to pkg/models so internal/ollama and internal/gemini share types without cross-dependency.

## New Package: internal/ollama/

- `client.go` -- Raw HTTP client for Ollama REST API (/api/generate, /api/tags)
- `guardian.go` -- Sensitivity classifier (Granite Guardian)
- `assigner.go` -- Local task assigner (Granite 3.2:8b)
- `decisions.go` -- Local decision extractor (local-only mode)
- All with comprehensive httptest-based tests

## Testing

- 13 test packages pass with -race -count=1
- 41 new tests across client, guardian, assigner, decisions
- All Ollama HTTP interactions use httptest.NewServer (no real Ollama needed)